### PR TITLE
[ch32573] add new fulfillment types to fulfilment options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/basket-service/__mocks__/basket.ts
+++ b/src/basket-service/__mocks__/basket.ts
@@ -15,7 +15,9 @@ export const basketDataMock = {
     charge: {
       value: 100,
       currency: 'GBP',
-    }
+    },
+    prePurchaseText: 'Your tickets will be available at the box office when you arrive for the show.',
+    postPurchaseText: 'Tickets will be held for {name} at the box office 30 minutes prior to showtime.'
   },
   allowFlexiTickets: true,
   status: BasketStatus.Active,

--- a/src/basket-service/__mocks__/delivery.ts
+++ b/src/basket-service/__mocks__/delivery.ts
@@ -6,6 +6,8 @@ const deliveryDataMock = {
     value: 100,
     currency: 'GBP',
   },
+  prePurchaseText: 'Your tickets will be available at the box office when you arrive for the show.',
+  postPurchaseText: 'Tickets will be held for {name} at the box office 30 minutes prior to showtime.'
 };
 
 export const deliveriesMock = [ deliveryDataMock, deliveryDataMock ];

--- a/src/basket-service/models/__tests__/delivery.spec.ts
+++ b/src/basket-service/models/__tests__/delivery.spec.ts
@@ -71,4 +71,20 @@ describe('Delivery', () => {
       expect(delivery.getName()).toBe(deliverySettings[postageCode].name);
     });
   });
+
+  describe('getPrePurchaseText function', () => {
+    it('should return pre-purchase text', () => {
+      const delivery = getDelivery();
+
+      expect(delivery.getPrePurchaseText()).toBe(deliveryData.prePurchaseText);
+    });
+  });
+
+  describe('getPostPurchaseText function', () => {
+    it('should return post-purchase text', () => {
+      const delivery = getDelivery();
+
+      expect(delivery.getPostPurchaseText()).toBe(deliveryData.postPurchaseText);
+    });
+  });
 });

--- a/src/basket-service/models/delivery.ts
+++ b/src/basket-service/models/delivery.ts
@@ -7,6 +7,8 @@ import { checkRequiredProperty } from "../../utils/validator";
 export class Delivery {
   private readonly amount: Amount;
   private readonly method: DeliveryMethod;
+  private readonly prePurchaseText: string;
+  private readonly postPurchaseText: string;
   private name: string;
 
   constructor (
@@ -16,10 +18,12 @@ export class Delivery {
     checkRequiredProperty(deliveryData, 'Delivery: delivery data');
     checkRequiredProperty(itemsToDeliver, 'Delivery: collection with items to deliver');
 
-    const { method, charge } = deliveryData;
+    const { method, charge, prePurchaseText, postPurchaseText } = deliveryData;
 
     this.amount = charge;
     this.method = method;
+    this.prePurchaseText = prePurchaseText;
+    this.postPurchaseText = postPurchaseText;
     this.setName(itemsToDeliver);
   }
 
@@ -33,6 +37,14 @@ export class Delivery {
 
   getName () {
     return this.name;
+  }
+
+  getPrePurchaseText () {
+    return this.prePurchaseText;
+  }
+
+  getPostPurchaseText () {
+    return this.postPurchaseText;
   }
 
   private setName (itemsToDeliver: BasketItemsCollection) {

--- a/src/basket-service/services/__tests__/repository-provider.spec.ts
+++ b/src/basket-service/services/__tests__/repository-provider.spec.ts
@@ -202,6 +202,8 @@ describe('Basket repository', () => {
         value: 200,
         currency: 'USD',
       },
+      prePurchaseText: 'Your tickets will be available at the box office when you arrive for the show.',
+      postPurchaseText: 'Tickets will be held for {name} at the box office 30 minutes prior to showtime.'
     };
     const basket = new Basket(basketDataMock);
 

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -62,6 +62,8 @@ export interface Promotion {
 export interface DeliveryData {
   method: DeliveryMethod;
   charge: Amount;
+  prePurchaseText: string;
+  postPurchaseText: string;
 }
 
 export interface BasketData {


### PR DESCRIPTION
**What are the relevant Clubhouse tasks?**
As part of: https://app.clubhouse.io/todaytix/story/32573/add-new-fulfillment-types-to-fulfilment-options-component

**What does this PR do & what background information is important for this PR?**
This PR add fields prePurchaseText and postPurchaseText as part of the Delivery Data returned from the API. This helps enable the use of these text responses in the front-end Fulfillment and Delivery Instructions component, rather than copy hardcoded in the front-end. 

**Checklist:**
- [x] New tests added
- [x] Checked for any new warnings or exceptions in the logs.