### PR TITLE
[ch32573] update deliveryMethod deliverySettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,12 @@ enum DeliveryMethod {
     Collection = "collection",
     Postage = "postage",
     Eticket = "eticket",
-    Evoucher = "evoucher"
+    Evoucher = "evoucher",
+    PrintBoxOffice = 'print_box_office',
+    HandDelivered = 'hand_delivered', 
+    DelayedBarcode = 'delayed_barcode',
+    Streaming = 'streaming',
+    Supplier = 'supplier',
 }
 
 interface Amount {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/basket-service/constants/delivery-settings.ts
+++ b/src/basket-service/constants/delivery-settings.ts
@@ -2,7 +2,7 @@ import { DeliveryMethod } from '../typings';
 
 export const deliverySettings = {
   [DeliveryMethod.Collection]: {
-    name: "Collect at the Box Office",
+    name: "Collect at the venue",
     voucherName: "Free postal delivery",
     attractionName: "Print at home voucher",
   },
@@ -10,9 +10,24 @@ export const deliverySettings = {
     name: "By Post – UK Addresses only",
   },
   [DeliveryMethod.Eticket]: {
-    name: "Print at Home",
+    name: "Download as E-Ticket",
   },
   [DeliveryMethod.Evoucher]: {
     name: "Print at Home E-Voucher",
+  },
+  [DeliveryMethod.HandDelivered]: {
+    name: "Hand Delivered",
+  },
+  [DeliveryMethod.PrintBoxOffice]: {
+    name: "Collect at the venue",
+  },
+  [DeliveryMethod.DelayedBarcode]: {
+    name: "Download as E-Ticket",
+  },
+  [DeliveryMethod.Streaming]: {
+    name: "Streaming",
+  },
+  [DeliveryMethod.Supplier]: {
+    name: "Download as E-Ticket",
   },
 };

--- a/src/basket-service/models/__tests__/delivery.spec.ts
+++ b/src/basket-service/models/__tests__/delivery.spec.ts
@@ -70,6 +70,48 @@ describe('Delivery', () => {
 
       expect(delivery.getName()).toBe(deliverySettings[postageCode].name);
     });
+
+    it('should get eVoucher name', () => {
+      const eVoucherCode = DeliveryMethod.Evoucher;
+      const delivery = getDelivery(ProductType.Show, eVoucherCode);
+
+      expect(delivery.getName()).toBe(deliverySettings[eVoucherCode].name);
+    });
+
+    it('should get HandDelivered name', () => {
+      const handDeliveredCode = DeliveryMethod.HandDelivered;
+      const delivery = getDelivery(ProductType.Show, handDeliveredCode);
+
+      expect(delivery.getName()).toBe(deliverySettings[handDeliveredCode].name);
+    });
+
+    it('should get PrintBoxOffice name', () => {
+      const printBoxOfficeCode = DeliveryMethod.PrintBoxOffice;
+      const delivery = getDelivery(ProductType.Show, printBoxOfficeCode);
+
+      expect(delivery.getName()).toBe(deliverySettings[printBoxOfficeCode].name);
+    });
+
+    it('should get DelayedBarcode name', () => {
+      const delayedBarcodeCode = DeliveryMethod.DelayedBarcode;
+      const delivery = getDelivery(ProductType.Show, delayedBarcodeCode);
+
+      expect(delivery.getName()).toBe(deliverySettings[delayedBarcodeCode].name);
+    });
+    
+    it('should get Streaming name', () => {
+      const streamingCode = DeliveryMethod.Streaming;
+      const delivery = getDelivery(ProductType.Show, streamingCode);
+
+      expect(delivery.getName()).toBe(deliverySettings[streamingCode].name);
+    });
+
+    it('should get Supplier name', () => {
+      const supplierCode = DeliveryMethod.Supplier;
+      const delivery = getDelivery(ProductType.Show, supplierCode);
+
+      expect(delivery.getName()).toBe(deliverySettings[supplierCode].name);
+    });
   });
 
   describe('getPrePurchaseText function', () => {

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -5,6 +5,11 @@ export enum DeliveryMethod {
   Postage = 'postage',
   Eticket = 'eticket',
   Evoucher = 'evoucher',
+  PrintBoxOffice = 'print_box_office',
+  HandDelivered = 'hand_delivered', 
+  DelayedBarcode = 'delayed_barcode',
+  Streaming = 'streaming',
+  Supplier = 'supplier',
 }
 
 export enum BasketStatus {


### PR DESCRIPTION
**What are the relevant Clubhouse tasks?**
As part of: https://app.clubhouse.io/todaytix/story/32573/add-new-fulfillment-types-to-fulfilment-options-component

**What does this PR do & what background information is important for this PR?**
This PR adds additional, eligible delivery methods (print_box_office, hand_delivered, delayed_barcode, streaming, supplier) to the deliveryMethod enum to be returned from the API. Additionally, in order to support this, the deliverySettings constant is updated with a name value for each new delivery method. 

**Checklist:**
- [x]  New tests added
- [x] Checked for any new warnings or exceptions in the logs.