### PR TITLE
[ch38111] Seat attributes with date and time not displayed in basket on Overture

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/venue-service/services/__tests__/repository-provider.spec.ts
+++ b/src/venue-service/services/__tests__/repository-provider.spec.ts
@@ -64,21 +64,35 @@ describe('Venue repository', () => {
     it('should throw an error if venue id is not defined', async () => {
       expect.assertions(1);
 
-      await expect(getSeatAttributesBySeatIds(null, null)).rejects.toEqual(new Error('getSeatAttributesBySeatIds: venue id is required'));
+      await expect(getSeatAttributesBySeatIds(null, null, null, null)).rejects.toEqual(new Error('getSeatAttributesBySeatIds: venue id is required'));
     });
 
     it('should throw an error if seat id collection is not defined', async () => {
       expect.assertions(1);
 
-      await expect(getSeatAttributesBySeatIds(venueId, null)).rejects.toEqual(new Error('getSeatAttributesBySeatIds: seat id collection is required'));
+      await expect(getSeatAttributesBySeatIds(venueId, null, null, null)).rejects.toEqual(new Error('getSeatAttributesBySeatIds: seat id collection is required'));
+    });
+
+    it('should throw an error if the performance date is not defined', async () => {
+      expect.assertions(1);
+
+      await expect(getSeatAttributesBySeatIds(venueId, seatIdCollection, null, null)).rejects.toEqual(new Error('getSeatAttributesBySeatIds: performance date is required'));
+    });
+
+    it('should throw an error if the performance time is not defined', async () => {
+      expect.assertions(1);
+
+      await expect(getSeatAttributesBySeatIds(venueId, seatIdCollection, performanceDate, null)).rejects.toEqual(new Error('getSeatAttributesBySeatIds: performance time is required'));
     });
 
     it('should call getSeatAttributes with valid arguments', async () => {
-      await getSeatAttributesBySeatIds(venueId, seatIdCollection);
+      await getSeatAttributesBySeatIds(venueId, seatIdCollection, performanceDate, performanceTime);
 
       expect(getSeatsData).toBeCalledWith({
         seatIdCollection,
         venueId,
+        performanceDate,
+        performanceTime
       });
     });
   });

--- a/src/venue-service/services/repository-provider.ts
+++ b/src/venue-service/services/repository-provider.ts
@@ -20,11 +20,13 @@ export const getVenueServiceRepository = (
     return seatAttributesData.map(seatAttributes => new SeatAttributes(seatAttributes));
   };
 
-  const getSeatAttributesBySeatIds = async (venueId: string, seatIdCollection: string[]) => {
+  const getSeatAttributesBySeatIds = async (venueId: string, seatIdCollection: string[], performanceDate: string, performanceTime: string) => {
     checkRequiredProperty(venueId, 'getSeatAttributesBySeatIds: venue id');
     checkRequiredProperty(seatIdCollection, 'getSeatAttributesBySeatIds: seat id collection');
+    checkRequiredProperty(performanceDate, 'getSeatAttributesBySeatIds: performance date');
+    checkRequiredProperty(performanceTime, 'getSeatAttributesBySeatIds: performance time');
 
-    const seatAttributesData = await venueApi.getSeatAttributes({ venueId, seatIdCollection });
+    const seatAttributesData = await venueApi.getSeatAttributes({ venueId, seatIdCollection, performanceDate, performanceTime });
 
     return seatAttributesData.map(seatAttributes => new SeatAttributes(seatAttributes));
   };


### PR DESCRIPTION
[[ch38111] Seat attributes with date and time not displayed in basket on Overture](https://app.clubhouse.io/todaytix/story/38111/seat-attributes-with-date-and-time-not-displayed-in-basket-on-overture)

Add `performanceDate` and `performanceTime` to `getSeatAttributesBySeatIds` as required properties.