### PR TITLE
[ch33348] Add anonymous ID to request header

### DIFF
--- a/src/utils/additional-headers.ts
+++ b/src/utils/additional-headers.ts
@@ -8,6 +8,8 @@ export const getAdditionalHeaders = ({
   const sourceNamePart = sourceName ? `${sourceName} | ` : '';
   const viewNamePart = viewName ? `${viewName} using ` : '';
   const requestInformation = `${sourceNamePart}${viewNamePart}JS SDK`;
+  const anonymousId = getAnonymousId();
+
   const header = {
     'x-ttg-client': requestInformation,
   };
@@ -16,5 +18,13 @@ export const getAdditionalHeaders = ({
     header['x-ttg-client-version'] = sourceVersion
   }
 
+  if (anonymousId) {
+    header['x-tt-anonymous-id'] = anonymousId
+  }
+
   return header;
+}
+
+export const getAnonymousId = () => {
+  return localStorage.getItem('ajs_anonymous_id');
 }


### PR DESCRIPTION
so that FE services can take the anonymous ID previously assigned by JS SDK and pass it down the stack to the BE services (and subsequently to TTG platform) and track user analytics consistently across the stacks.