### PR TITLE
[ch25084] Add Location to BasketData

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ interface RequestBasketData {
     shopperReference?: string;
     shopperCurrency?: string;
     exchangeRate?: number;
+    location: LocationSimpleData;
 }
 
 interface RequestBasketItemData {
@@ -114,6 +115,7 @@ interface RequestBasketItemData {
     faceValueInShopperCurrency?: Amount | null;
     adjustmentAmountInShopperCurrency?: Amount;
     salePriceInShopperCurrency?: Amount;
+    feeInShopperCurrency: Amount | null;
 }
 
 interface RequestSeat {
@@ -208,6 +210,7 @@ interface BasketItemData {
     salePriceInShopperCurrency: Amount;
     faceValueInShopperCurrency: Amount | null;
     adjustmentAmountInShopperCurrency: Amount;
+    feeInShopperCurrency: Amount | null;
     linkedReservationId?: number;
     seats?: ReservationSeat[];
 }
@@ -260,6 +263,7 @@ interface BasketItemData {
     salePriceInShopperCurrency: Amount;
     faceValueInShopperCurrency: Amount | null;
     adjustmentAmountInShopperCurrency: Amount;
+    feeInShopperCurrency: Amount | null;
     linkedReservationId?: number;
     seats?: ReservationSeat[];
 }

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ interface RequestBasketData {
     shopperReference?: string;
     shopperCurrency?: string;
     exchangeRate?: number;
+    location: LocationSimpleData;
 }
 
 interface RequestBasketItemData {

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ interface RequestBasketData {
     shopperReference?: string;
     shopperCurrency?: string;
     exchangeRate?: number;
-    location: LocationSimpleData;
 }
 
 interface RequestBasketItemData {

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ interface RequestBasketItemData {
     faceValueInShopperCurrency?: Amount | null;
     adjustmentAmountInShopperCurrency?: Amount;
     salePriceInShopperCurrency?: Amount;
+    feeInShopperCurrency?: Amount | null;
 }
 
 interface RequestSeat {
@@ -208,6 +209,7 @@ interface BasketItemData {
     salePriceInShopperCurrency: Amount;
     faceValueInShopperCurrency: Amount | null;
     adjustmentAmountInShopperCurrency: Amount;
+    feeInShopperCurrency: Amount | null;
     linkedReservationId?: number;
     seats?: ReservationSeat[];
 }
@@ -260,6 +262,7 @@ interface BasketItemData {
     salePriceInShopperCurrency: Amount;
     faceValueInShopperCurrency: Amount | null;
     adjustmentAmountInShopperCurrency: Amount;
+    feeInShopperCurrency: Amount | null;
     linkedReservationId?: number;
     seats?: ReservationSeat[];
 }

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ interface RequestBasketData {
     shopperReference?: string;
     shopperCurrency?: string;
     exchangeRate?: number;
-    location: LocationSimpleData;
 }
 
 interface RequestBasketItemData {
@@ -115,7 +114,6 @@ interface RequestBasketItemData {
     faceValueInShopperCurrency?: Amount | null;
     adjustmentAmountInShopperCurrency?: Amount;
     salePriceInShopperCurrency?: Amount;
-    feeInShopperCurrency: Amount | null;
 }
 
 interface RequestSeat {
@@ -210,7 +208,6 @@ interface BasketItemData {
     salePriceInShopperCurrency: Amount;
     faceValueInShopperCurrency: Amount | null;
     adjustmentAmountInShopperCurrency: Amount;
-    feeInShopperCurrency: Amount | null;
     linkedReservationId?: number;
     seats?: ReservationSeat[];
 }
@@ -263,7 +260,6 @@ interface BasketItemData {
     salePriceInShopperCurrency: Amount;
     faceValueInShopperCurrency: Amount | null;
     adjustmentAmountInShopperCurrency: Amount;
-    feeInShopperCurrency: Amount | null;
     linkedReservationId?: number;
     seats?: ReservationSeat[];
 }

--- a/src/basket-service/__mocks__/basket-item.ts
+++ b/src/basket-service/__mocks__/basket-item.ts
@@ -32,11 +32,7 @@ export const basketItemDataMock = {
     currency: 'GBP',
   },
   adjustmentAmountInShopperCurrency: {
-    value: 25,
+    value: 20,
     currency: 'GBP',
   },
-  feeInShopperCurrency: {
-    value: 5,
-    currency: 'GBP',
-  }
 };

--- a/src/basket-service/__mocks__/basket-item.ts
+++ b/src/basket-service/__mocks__/basket-item.ts
@@ -32,7 +32,11 @@ export const basketItemDataMock = {
     currency: 'GBP',
   },
   adjustmentAmountInShopperCurrency: {
-    value: 20,
+    value: 25,
     currency: 'GBP',
   },
+  feeInShopperCurrency: {
+    value: 5,
+    currency: 'GBP',
+  }
 };

--- a/src/basket-service/__mocks__/basket-item.ts
+++ b/src/basket-service/__mocks__/basket-item.ts
@@ -35,4 +35,8 @@ export const basketItemDataMock = {
     value: 20,
     currency: 'GBP',
   },
+  feeInShopperCurrency: {
+    value: 0,
+    currency: 'GBP',
+  }
 };

--- a/src/basket-service/__mocks__/basket.ts
+++ b/src/basket-service/__mocks__/basket.ts
@@ -37,4 +37,10 @@ export const basketDataMock = {
   },
   shopperReference: 'YmFza2V0QGVuY29yZXRpeC5jby51azpFQzRBIDFFTg==',
   shopperCurrency: 'GBP',
+  location: {
+    id: '2',
+    includeFees: true,
+    name: 'London',
+    regionCode: 'GB'
+  },
 };

--- a/src/basket-service/models/__tests__/basket-item.spec.ts
+++ b/src/basket-service/models/__tests__/basket-item.spec.ts
@@ -130,7 +130,7 @@ describe('Basket item', () => {
   describe('getAdjustmentAmount function', () => {
     it('should get adjustment amount', () => {
       expect(getBasketItem().getAdjustmentAmount()).toEqual({
-        value: 20,
+        value: 25,
         currency: 'GBP',
       });
     });
@@ -176,7 +176,7 @@ describe('Basket item', () => {
 
   describe('getPromotionDiscount function', () => {
     it('should get promotion discount', () => {
-      expect(getBasketItem().getPromotionDiscount()).toBe(200);
+      expect(getBasketItem().getPromotionDiscount()).toBe(250);
       expect(getBasketItem({ adjustmentAmountInShopperCurrency: null }).getPromotionDiscount()).toBe(0);
     });
   });
@@ -210,6 +210,12 @@ describe('Basket item', () => {
   describe('getTotalPriceWithoutPromotion function', () => {
     it('should get total price without promotion', () => {
       expect(getBasketItem().getTotalPriceWithoutPromotion()).toBe(700);
+    });
+  });
+
+  describe('getTotalPriceWithoutFees function', () => {
+    it('should get total price without promotion', () => {
+      expect(getBasketItem().getTotalPriceWithoutFees()).toBe(450);
     });
   });
 

--- a/src/basket-service/models/__tests__/basket-item.spec.ts
+++ b/src/basket-service/models/__tests__/basket-item.spec.ts
@@ -130,7 +130,7 @@ describe('Basket item', () => {
   describe('getAdjustmentAmount function', () => {
     it('should get adjustment amount', () => {
       expect(getBasketItem().getAdjustmentAmount()).toEqual({
-        value: 25,
+        value: 20,
         currency: 'GBP',
       });
     });
@@ -176,7 +176,7 @@ describe('Basket item', () => {
 
   describe('getPromotionDiscount function', () => {
     it('should get promotion discount', () => {
-      expect(getBasketItem().getPromotionDiscount()).toBe(250);
+      expect(getBasketItem().getPromotionDiscount()).toBe(200);
       expect(getBasketItem({ adjustmentAmountInShopperCurrency: null }).getPromotionDiscount()).toBe(0);
     });
   });
@@ -210,12 +210,6 @@ describe('Basket item', () => {
   describe('getTotalPriceWithoutPromotion function', () => {
     it('should get total price without promotion', () => {
       expect(getBasketItem().getTotalPriceWithoutPromotion()).toBe(700);
-    });
-  });
-
-  describe('getTotalPriceWithoutFees function', () => {
-    it('should get total price without promotion', () => {
-      expect(getBasketItem().getTotalPriceWithoutFees()).toBe(450);
     });
   });
 

--- a/src/basket-service/models/__tests__/basket-item.spec.ts
+++ b/src/basket-service/models/__tests__/basket-item.spec.ts
@@ -109,6 +109,15 @@ describe('Basket item', () => {
     });
   });
 
+  describe('getFee function', () => {
+    it('should get fee details', () => {
+      expect(getBasketItem().getFee()).toEqual({
+        value: 0,
+        currency: 'GBP',
+      });
+    });
+  });
+
   describe('getSalePrice function', () => {
     it('should get sale price details', () => {
       expect(getBasketItem().getSalePrice()).toEqual({
@@ -139,6 +148,12 @@ describe('Basket item', () => {
   describe('getFaceValueAmount function', () => {
     it('should get product face value amount', () => {
       expect(getBasketItem().getFaceValueAmount()).toBe(100);
+    });
+  });
+
+  describe('getFeeAmount function', () => {
+    it('should get fee amount', () => {
+      expect(getBasketItem().getFeeAmount()).toBe(0);
     });
   });
 

--- a/src/basket-service/models/__tests__/basket.spec.ts
+++ b/src/basket-service/models/__tests__/basket.spec.ts
@@ -210,13 +210,19 @@ describe('Basket', () => {
 
   describe('getTotalPromotionDiscount function', () => {
     it('should get total promotion discount', () => {
-      expect(getBasket().getTotalPromotionDiscount()).toBe(400);
+      expect(getBasket().getTotalPromotionDiscount()).toBe(500);
     });
   });
 
   describe('getTotalPriceBeforeDiscount function', () => {
     it('should get total price before discount', () => {
       expect(getBasket().getTotalPriceBeforeDiscount()).toBe(2000);
+    });
+  });
+
+  describe('getTotalPriceWithoutFees function', () => {
+    it('should get total price before discount', () => {
+      expect(getBasket().getTotalPriceWithoutFees()).toBe(900);
     });
   });
 

--- a/src/basket-service/models/__tests__/basket.spec.ts
+++ b/src/basket-service/models/__tests__/basket.spec.ts
@@ -210,19 +210,13 @@ describe('Basket', () => {
 
   describe('getTotalPromotionDiscount function', () => {
     it('should get total promotion discount', () => {
-      expect(getBasket().getTotalPromotionDiscount()).toBe(500);
+      expect(getBasket().getTotalPromotionDiscount()).toBe(400);
     });
   });
 
   describe('getTotalPriceBeforeDiscount function', () => {
     it('should get total price before discount', () => {
       expect(getBasket().getTotalPriceBeforeDiscount()).toBe(2000);
-    });
-  });
-
-  describe('getTotalPriceWithoutFees function', () => {
-    it('should get total price before discount', () => {
-      expect(getBasket().getTotalPriceWithoutFees()).toBe(900);
     });
   });
 

--- a/src/basket-service/models/__tests__/basket.spec.ts
+++ b/src/basket-service/models/__tests__/basket.spec.ts
@@ -319,6 +319,12 @@ describe('Basket', () => {
     });
   });
 
+  describe('getLocation function', () => {
+    it('should get location', () => {
+      expect(getBasket().getLocation()).toEqual(basketDataMock.location);
+    });
+  });
+
   describe('prepareBasketData function', () => {
     it('should map basket items into reservations', () => {
       expect(getBasket().prepareBasketData().reservations).toEqual([

--- a/src/basket-service/models/basket-item.ts
+++ b/src/basket-service/models/basket-item.ts
@@ -15,6 +15,7 @@ export class BasketItem {
   private readonly salePriceInShopperCurrency: Amount;
   private readonly adjustedSalePriceInShopperCurrency: Amount;
   private readonly adjustmentAmountInShopperCurrency: Amount;
+  private readonly feeInShopperCurrency: Amount | null;
   private readonly date: Date;
   private readonly rawDate: string;
   private readonly seats: ReservationSeat[];
@@ -36,6 +37,7 @@ export class BasketItem {
       adjustedSalePriceInShopperCurrency,
       salePriceInShopperCurrency,
       adjustmentAmountInShopperCurrency,
+      feeInShopperCurrency,
       date,
       items,
       venueId,
@@ -52,6 +54,7 @@ export class BasketItem {
     this.adjustedSalePriceInShopperCurrency = adjustedSalePriceInShopperCurrency;
     this.salePriceInShopperCurrency = salePriceInShopperCurrency;
     this.adjustmentAmountInShopperCurrency = adjustmentAmountInShopperCurrency;
+    this.feeInShopperCurrency = feeInShopperCurrency;
     this.date = date ? new Date(date) : null;
     this.rawDate = date;
     this.seats = items || seats;
@@ -127,6 +130,10 @@ export class BasketItem {
     return this.salePriceInShopperCurrency.value;
   }
 
+  getFeeAmount () {
+    return this.feeInShopperCurrency ? this.feeInShopperCurrency.value : null;
+  }
+
   hasDiscount () {
     const faceValueAmount = this.getFaceValueAmount();
 
@@ -159,6 +166,10 @@ export class BasketItem {
 
   getTotalPriceWithoutPromotion () {
     return this.quantity * this.getOriginalSalePriceAmount();
+  }
+
+  getTotalPriceWithoutFees () {
+    return this.quantity * (this.getSalePriceAmount() - this.getFeeAmount());
   }
 
   getPriceBeforeDiscount () {

--- a/src/basket-service/models/basket-item.ts
+++ b/src/basket-service/models/basket-item.ts
@@ -15,6 +15,7 @@ export class BasketItem {
   private readonly salePriceInShopperCurrency: Amount;
   private readonly adjustedSalePriceInShopperCurrency: Amount;
   private readonly adjustmentAmountInShopperCurrency: Amount;
+  private readonly feeInShopperCurrency: Amount | null;
   private readonly date: Date;
   private readonly rawDate: string;
   private readonly seats: ReservationSeat[];
@@ -36,6 +37,7 @@ export class BasketItem {
       adjustedSalePriceInShopperCurrency,
       salePriceInShopperCurrency,
       adjustmentAmountInShopperCurrency,
+      feeInShopperCurrency,
       date,
       items,
       venueId,
@@ -52,6 +54,7 @@ export class BasketItem {
     this.adjustedSalePriceInShopperCurrency = adjustedSalePriceInShopperCurrency;
     this.salePriceInShopperCurrency = salePriceInShopperCurrency;
     this.adjustmentAmountInShopperCurrency = adjustmentAmountInShopperCurrency;
+    this.feeInShopperCurrency = feeInShopperCurrency;
     this.date = date ? new Date(date) : null;
     this.rawDate = date;
     this.seats = items || seats;
@@ -115,6 +118,10 @@ export class BasketItem {
     return this.adjustmentAmountInShopperCurrency;
   }
 
+  getFee () {
+    return this.feeInShopperCurrency;
+  }
+
   getFaceValueAmount () {
     return this.faceValueInShopperCurrency ? this.faceValueInShopperCurrency.value : null;
   }
@@ -125,6 +132,10 @@ export class BasketItem {
 
   getOriginalSalePriceAmount () {
     return this.salePriceInShopperCurrency.value;
+  }
+
+  getFeeAmount() {
+    return this.feeInShopperCurrency ? this.feeInShopperCurrency.value : null;
   }
 
   hasDiscount () {

--- a/src/basket-service/models/basket-item.ts
+++ b/src/basket-service/models/basket-item.ts
@@ -15,7 +15,6 @@ export class BasketItem {
   private readonly salePriceInShopperCurrency: Amount;
   private readonly adjustedSalePriceInShopperCurrency: Amount;
   private readonly adjustmentAmountInShopperCurrency: Amount;
-  private readonly feeInShopperCurrency: Amount | null;
   private readonly date: Date;
   private readonly rawDate: string;
   private readonly seats: ReservationSeat[];
@@ -37,7 +36,6 @@ export class BasketItem {
       adjustedSalePriceInShopperCurrency,
       salePriceInShopperCurrency,
       adjustmentAmountInShopperCurrency,
-      feeInShopperCurrency,
       date,
       items,
       venueId,
@@ -54,7 +52,6 @@ export class BasketItem {
     this.adjustedSalePriceInShopperCurrency = adjustedSalePriceInShopperCurrency;
     this.salePriceInShopperCurrency = salePriceInShopperCurrency;
     this.adjustmentAmountInShopperCurrency = adjustmentAmountInShopperCurrency;
-    this.feeInShopperCurrency = feeInShopperCurrency;
     this.date = date ? new Date(date) : null;
     this.rawDate = date;
     this.seats = items || seats;
@@ -130,10 +127,6 @@ export class BasketItem {
     return this.salePriceInShopperCurrency.value;
   }
 
-  getFeeAmount () {
-    return this.feeInShopperCurrency ? this.feeInShopperCurrency.value : null;
-  }
-
   hasDiscount () {
     const faceValueAmount = this.getFaceValueAmount();
 
@@ -166,10 +159,6 @@ export class BasketItem {
 
   getTotalPriceWithoutPromotion () {
     return this.quantity * this.getOriginalSalePriceAmount();
-  }
-
-  getTotalPriceWithoutFees () {
-    return this.quantity * (this.getSalePriceAmount() - this.getFeeAmount());
   }
 
   getPriceBeforeDiscount () {

--- a/src/basket-service/models/basket.ts
+++ b/src/basket-service/models/basket.ts
@@ -216,6 +216,10 @@ export class Basket {
     return this.basketData.channelId;
   }
 
+  getLocation () {
+    return this.basketData.location;
+  }
+
   prepareBasketData (upsellProducts?: UpsellApiProductData) {
     const { reservations } = this.basketData;
     const itemsCollection = new BasketItemsCollection(reservations);

--- a/src/basket-service/models/basket.ts
+++ b/src/basket-service/models/basket.ts
@@ -144,6 +144,10 @@ export class Basket {
     return this.reduceBasketItemsAmount((totalPrice, item) => totalPrice + item.getPriceBeforeDiscount());
   }
 
+  getTotalPriceWithoutFees () {
+    return this.reduceBasketItemsAmount((totalPrice, item) => totalPrice + item.getTotalPriceWithoutFees());
+  }
+
   hasDiscount () {
     return this.itemsCollection.getItems().some(item => item.hasDiscount());
   }

--- a/src/basket-service/models/basket.ts
+++ b/src/basket-service/models/basket.ts
@@ -144,10 +144,6 @@ export class Basket {
     return this.reduceBasketItemsAmount((totalPrice, item) => totalPrice + item.getPriceBeforeDiscount());
   }
 
-  getTotalPriceWithoutFees () {
-    return this.reduceBasketItemsAmount((totalPrice, item) => totalPrice + item.getTotalPriceWithoutFees());
-  }
-
   hasDiscount () {
     return this.itemsCollection.getItems().some(item => item.hasDiscount());
   }

--- a/src/basket-service/services/api-provider.ts
+++ b/src/basket-service/services/api-provider.ts
@@ -31,6 +31,7 @@ export const getBasketServiceApi = (
       reservations,
       shopperCurrency,
       hasFlexiTickets,
+      location,
     } = basketData;
 
     return httpClient.patch(basketsPath, {
@@ -41,6 +42,7 @@ export const getBasketServiceApi = (
       reservations,
       shopperCurrency,
       hasFlexiTickets,
+      location,
     }, {
       headers: {
         ...getRequestHeadersByChannel(channelId),

--- a/src/basket-service/services/api-provider.ts
+++ b/src/basket-service/services/api-provider.ts
@@ -31,7 +31,6 @@ export const getBasketServiceApi = (
       reservations,
       shopperCurrency,
       hasFlexiTickets,
-      location,
     } = basketData;
 
     return httpClient.patch(basketsPath, {
@@ -42,7 +41,6 @@ export const getBasketServiceApi = (
       reservations,
       shopperCurrency,
       hasFlexiTickets,
-      location,
     }, {
       headers: {
         ...getRequestHeadersByChannel(channelId),

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -50,6 +50,7 @@ export interface BasketItemData {
   salePriceInShopperCurrency: Amount;
   faceValueInShopperCurrency: Amount | null;
   adjustmentAmountInShopperCurrency: Amount;
+  feeInShopperCurrency: Amount | null;
   linkedReservationId?: number;
   seats?: ReservationSeat[];
 }
@@ -122,6 +123,7 @@ export interface RequestBasketItemData {
   faceValueInShopperCurrency?: Amount | null;
   adjustmentAmountInShopperCurrency?: Amount;
   salePriceInShopperCurrency?: Amount;
+  feeInShopperCurrency: Amount | null;
 }
 
 export interface RequestBasketData {

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -50,7 +50,6 @@ export interface BasketItemData {
   salePriceInShopperCurrency: Amount;
   faceValueInShopperCurrency: Amount | null;
   adjustmentAmountInShopperCurrency: Amount;
-  feeInShopperCurrency: Amount | null;
   linkedReservationId?: number;
   seats?: ReservationSeat[];
 }
@@ -123,7 +122,6 @@ export interface RequestBasketItemData {
   faceValueInShopperCurrency?: Amount | null;
   adjustmentAmountInShopperCurrency?: Amount;
   salePriceInShopperCurrency?: Amount;
-  feeInShopperCurrency: Amount | null;
 }
 
 export interface RequestBasketData {

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -96,7 +96,7 @@ export interface BasketData {
   missedPromotions?: Promotion[];
   hasFlexiTickets?: boolean;
   allowFlexiTickets?: boolean;
-  location: LocationSimpleData;
+  location?: LocationSimpleData;
 }
 
 interface RequestSeat {
@@ -138,7 +138,6 @@ export interface RequestBasketData {
   shopperCurrency?: string;
   exchangeRate?: number;
   hasFlexiTickets?: boolean;
-  location: LocationSimpleData;
 }
 
 export enum BasketLocationType {

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -71,6 +71,13 @@ export interface DeliveryData {
   postPurchaseText: string;
 }
 
+export interface LocationSimpleData {
+  id: string;
+  name: string;
+  regionCode: string;
+  includeFees: boolean;
+}
+
 export interface BasketData {
   channelId: string;
   reservations: BasketItemData[];
@@ -89,6 +96,7 @@ export interface BasketData {
   missedPromotions?: Promotion[];
   hasFlexiTickets?: boolean;
   allowFlexiTickets?: boolean;
+  location: LocationSimpleData;
 }
 
 interface RequestSeat {
@@ -130,6 +138,7 @@ export interface RequestBasketData {
   shopperCurrency?: string;
   exchangeRate?: number;
   hasFlexiTickets?: boolean;
+  location: LocationSimpleData;
 }
 
 export enum BasketLocationType {

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -50,6 +50,7 @@ export interface BasketItemData {
   salePriceInShopperCurrency: Amount;
   faceValueInShopperCurrency: Amount | null;
   adjustmentAmountInShopperCurrency: Amount;
+  feeInShopperCurrency: Amount | null;
   linkedReservationId?: number;
   seats?: ReservationSeat[];
 }
@@ -122,6 +123,7 @@ export interface RequestBasketItemData {
   faceValueInShopperCurrency?: Amount | null;
   adjustmentAmountInShopperCurrency?: Amount;
   salePriceInShopperCurrency?: Amount;
+  feeInShopperCurrency?: Amount | null;
 }
 
 export interface RequestBasketData {


### PR DESCRIPTION
#### What are the relevant Clubhouse tasks?
https://app.clubhouse.io/todaytix/story/25084/separate-out-fee-display-in-line-item-order-total-components-for-products-in-the-us-and-ca

#### Has a post-huddle with QA/Product/Design happened?
N/A

#### What does this PR do & what background information is important for this PR?
This PR adds location to BasketData to enable the basket page and order summary components on the frontend to know whether a hold/basket includes tickets to a show that is in a location where fees should be included or separated from the subtotal price. If the fees should be separated, we'll need to update the UI to support this in basket_fe. 

This PR also adds feeInShopperCurrency to BasketItemData (this was always passed to basket_fe but not used until now).