### PR TITLE
[sc-47643] New methods to render appropriate basket pricing info

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ interface RequestBasketItemData {
     adjustmentAmountInShopperCurrency?: Amount;
     salePriceInShopperCurrency?: Amount;
     feeInShopperCurrency?: Amount | null;
+    deliveryFeeInShopperCurrency?: Amount | null;
 }
 
 interface RequestSeat {
@@ -210,6 +211,7 @@ interface BasketItemData {
     faceValueInShopperCurrency: Amount | null;
     adjustmentAmountInShopperCurrency: Amount;
     feeInShopperCurrency: Amount | null;
+    deliveryFeeInShopperCurrency: Amount | null;
     linkedReservationId?: number;
     seats?: ReservationSeat[];
 }
@@ -263,6 +265,7 @@ interface BasketItemData {
     faceValueInShopperCurrency: Amount | null;
     adjustmentAmountInShopperCurrency: Amount;
     feeInShopperCurrency: Amount | null;
+    deliveryFeeInShopperCurrency: Amount | null;
     linkedReservationId?: number;
     seats?: ReservationSeat[];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/basket-service/__mocks__/basket-item.ts
+++ b/src/basket-service/__mocks__/basket-item.ts
@@ -40,7 +40,7 @@ export const basketItemDataMock = {
     currency: 'GBP',
   },
   deliveryFeeInShopperCurrency: {
-    value: 100,
+    value: 10,
     currency: 'GBP',
   }
 };

--- a/src/basket-service/__mocks__/basket-item.ts
+++ b/src/basket-service/__mocks__/basket-item.ts
@@ -38,5 +38,9 @@ export const basketItemDataMock = {
   feeInShopperCurrency: {
     value: 0,
     currency: 'GBP',
+  },
+  deliveryFeeInShopperCurrency: {
+    value: 100,
+    currency: 'GBP',
   }
 };

--- a/src/basket-service/__mocks__/basket.ts
+++ b/src/basket-service/__mocks__/basket.ts
@@ -13,7 +13,7 @@ export const basketDataMock = {
   delivery: {
     method: DeliveryMethod.Collection,
     charge: {
-      value: 100,
+      value: 10,
       currency: 'GBP',
     },
     prePurchaseText: 'Your tickets will be available at the box office when you arrive for the show.',

--- a/src/basket-service/models/__tests__/basket-item.spec.ts
+++ b/src/basket-service/models/__tests__/basket-item.spec.ts
@@ -192,20 +192,20 @@ describe('Basket item', () => {
     });
   });
 
-  describe('getSalePriceAmountWithoutDeliveryFee function', () => {
-    it('should get sale price amount without delivery fee', () => {
-      expect(getBasketItem().getSalePriceAmountWithoutDeliveryFee()).toBe(60);
+  describe('getOriginalSalePriceAmountWithoutDeliveryFee function', () => {
+    it('should get original sale price amount without delivery fee', () => {
+      expect(getBasketItem().getOriginalSalePriceAmountWithoutDeliveryFee()).toBe(60);
     });
   });
 
-  describe('getSalePriceAmountWithoutFees function', () => {
-    it('should get sale price amount without any fees', () => {
+  describe('getOriginalSalePriceAmountWithoutFees function', () => {
+    it('should get original sale price amount without any fees', () => {
       expect(getBasketItem({
         feeInShopperCurrency: {
           value: 10,
           currency: 'GBP',
         },
-      }).getSalePriceAmountWithoutFees()).toBe(50);
+      }).getOriginalSalePriceAmountWithoutFees()).toBe(50);
     });
   });
 

--- a/src/basket-service/models/__tests__/basket-item.spec.ts
+++ b/src/basket-service/models/__tests__/basket-item.spec.ts
@@ -118,6 +118,15 @@ describe('Basket item', () => {
     });
   });
 
+  describe('getDeliveryFee function', () => {
+    it('should get delivery fee details', () => {
+      expect(getBasketItem().getDeliveryFee()).toEqual({
+        value: 10,
+        currency: 'GBP',
+      });
+    });
+  });
+
   describe('getSalePrice function', () => {
     it('should get sale price details', () => {
       expect(getBasketItem().getSalePrice()).toEqual({
@@ -161,6 +170,16 @@ describe('Basket item', () => {
     });
   });
 
+  describe('getDeliveryFeeAmount function', () => {
+    it('should get delivery fee amount', () => {
+      expect(getBasketItem().getDeliveryFeeAmount()).toBe(10);
+    });
+
+    it('should get null delivery fee amount if delivery fee is null', () => {
+      expect(getBasketItem({ deliveryFeeInShopperCurrency: null }).getDeliveryFeeAmount()).toBeNull();
+    });
+  });
+
   describe('getSalePriceAmount function', () => {
     it('should get product sale price amount', () => {
       expect(getBasketItem().getSalePriceAmount()).toBe(50);
@@ -173,13 +192,30 @@ describe('Basket item', () => {
     });
   });
 
+  describe('getSalePriceAmountWithoutDeliveryFee function', () => {
+    it('should get sale price amount without delivery fee', () => {
+      expect(getBasketItem().getSalePriceAmountWithoutDeliveryFee()).toBe(60);
+    });
+  });
+
+  describe('getSalePriceAmountWithoutFees function', () => {
+    it('should get sale price amount without any fees', () => {
+      expect(getBasketItem({
+        feeInShopperCurrency: {
+          value: 10,
+          currency: 'GBP',
+        },
+      }).getSalePriceAmountWithoutFees()).toBe(50);
+    });
+  });
+
   describe('hasDiscount function', () => {
     it('should get discount availability', () => {
       expect(getBasketItem().hasDiscount()).toBe(true);
       expect(getBasketItem({
         productType: ProductType.Show,
         salePriceInShopperCurrency: {
-          value: 100,
+          value: 110,
           currency: 'GBP',
         },
       }).hasDiscount()).toBe(false);
@@ -190,6 +226,30 @@ describe('Basket item', () => {
         productType: ProductType.Show,
         faceValueInShopperCurrency: null,
       }).hasDiscount()).toBe(false);
+    });
+  });
+
+  describe('hasDiscountWithoutFees function', () => {
+    it('should get discount availability without any fees', () => {
+      expect(getBasketItem().hasDiscountWithoutFees()).toBe(true);
+      expect(getBasketItem({
+        productType: ProductType.Show,
+        salePriceInShopperCurrency: {
+          value: 120,
+          currency: 'GBP',
+        },
+        feeInShopperCurrency: {
+          value: 10,
+          currency: 'GBP',
+        },
+      }).hasDiscountWithoutFees()).toBe(false);
+    });
+
+    it('should return false if face value is not defined', () => {
+      expect(getBasketItem({
+        productType: ProductType.Show,
+        faceValueInShopperCurrency: null,
+      }).hasDiscountWithoutFees()).toBe(false);
     });
   });
 
@@ -209,14 +269,28 @@ describe('Basket item', () => {
 
   describe('getDiscount function', () => {
     it('should get discount', () => {
-      expect(getBasketItem().getDiscount()).toBe(300);
+      expect(getBasketItem().getDiscount()).toBe(400);
     });
 
     it('should return 0 if there is no discount', () => {
       expect(getBasketItem({
         faceValueInShopperCurrency: { value: 100, currency: 'GBP' },
-        salePriceInShopperCurrency: { value: 100, currency: 'GBP' },
+        salePriceInShopperCurrency: { value: 110, currency: 'GBP' },
       }).getDiscount()).toBe(0);
+    });
+  });
+
+  describe('getDiscountWithoutFees function', () => {
+    it('should get discount without any fees', () => {
+      expect(getBasketItem().getDiscountWithoutFees()).toBe(400);
+    });
+
+    it('should return 0 if there is no discount', () => {
+      expect(getBasketItem({
+        faceValueInShopperCurrency: { value: 100, currency: 'GBP' },
+        salePriceInShopperCurrency: { value: 120, currency: 'GBP' },
+        feeInShopperCurrency: { value: 10, currency: 'GBP' },
+      }).getDiscountWithoutFees()).toBe(0);
     });
   });
 
@@ -229,6 +303,23 @@ describe('Basket item', () => {
   describe('getTotalPriceWithoutPromotion function', () => {
     it('should get total price without promotion', () => {
       expect(getBasketItem().getTotalPriceWithoutPromotion()).toBe(700);
+    });
+  });
+
+  describe('getTotalPriceWithoutDeliveryFee function', () => {
+    it('should get total price without delivery fee', () => {
+      expect(getBasketItem().getTotalPriceWithoutDeliveryFee()).toBe(600);
+    });
+  });
+
+  describe('getTotalPriceWithoutFees function', () => {
+    it('should get total price without any fees', () => {
+      expect(getBasketItem({
+        feeInShopperCurrency: {
+          value: 10,
+          currency: 'GBP'
+        },
+      }).getTotalPriceWithoutFees()).toBe(500);
     });
   });
 

--- a/src/basket-service/models/__tests__/basket.spec.ts
+++ b/src/basket-service/models/__tests__/basket.spec.ts
@@ -204,7 +204,7 @@ describe('Basket', () => {
 
   describe('getTotalDiscount function', () => {
     it('should get total discount', () => {
-      expect(getBasket().getTotalDiscount()).toBe(600);
+      expect(getBasket().getTotalDiscount()).toBe(800);
     });
   });
 

--- a/src/basket-service/models/basket-item.ts
+++ b/src/basket-service/models/basket-item.ts
@@ -149,12 +149,12 @@ export class BasketItem {
     return this.deliveryFeeInShopperCurrency ? this.deliveryFeeInShopperCurrency.value : null;
   }
 
-  getSalePriceAmountWithoutDeliveryFee () {
+  getOriginalSalePriceAmountWithoutDeliveryFee () {
     return this.getOriginalSalePriceAmount() - this.getDeliveryFeeAmount();
   }
 
-  getSalePriceAmountWithoutFees () {
-    return this.getSalePriceAmountWithoutDeliveryFee() - this.getFeeAmount();
+  getOriginalSalePriceAmountWithoutFees () {
+    return this.getOriginalSalePriceAmountWithoutDeliveryFee() - this.getFeeAmount();
   }
 
   hasDiscount () {
@@ -164,7 +164,7 @@ export class BasketItem {
       return false;
     }
 
-    return faceValueAmount > this.getSalePriceAmountWithoutDeliveryFee();
+    return faceValueAmount > this.getOriginalSalePriceAmountWithoutDeliveryFee();
   }
 
   hasDiscountWithoutFees () {
@@ -174,7 +174,7 @@ export class BasketItem {
       return false;
     }
 
-    return faceValueAmount > this.getSalePriceAmountWithoutFees();
+    return faceValueAmount > this.getOriginalSalePriceAmountWithoutFees();
   }
 
   getPromotionDiscount () {
@@ -189,7 +189,7 @@ export class BasketItem {
     const hasDiscount = this.hasDiscount();
 
     return hasDiscount
-      ? this.quantity * (this.getFaceValueAmount() - this.getSalePriceAmountWithoutDeliveryFee())
+      ? this.quantity * (this.getFaceValueAmount() - this.getOriginalSalePriceAmountWithoutDeliveryFee())
       : 0;
   }
 
@@ -197,7 +197,7 @@ export class BasketItem {
     const hasDiscount = this.hasDiscountWithoutFees();
 
     return hasDiscount
-      ? this.quantity * (this.getFaceValueAmount() - this.getSalePriceAmountWithoutFees())
+      ? this.quantity * (this.getFaceValueAmount() - this.getOriginalSalePriceAmountWithoutFees())
       : 0;
   }
 
@@ -210,11 +210,11 @@ export class BasketItem {
   }
 
   getTotalPriceWithoutDeliveryFee () {
-    return this.quantity * this.getSalePriceAmountWithoutDeliveryFee();
+    return this.quantity * this.getOriginalSalePriceAmountWithoutDeliveryFee();
   }
 
   getTotalPriceWithoutFees () {
-    return this.quantity * this.getSalePriceAmountWithoutFees();
+    return this.quantity * this.getOriginalSalePriceAmountWithoutFees();
   }
 
   getPriceBeforeDiscount () {

--- a/src/basket-service/models/basket-item.ts
+++ b/src/basket-service/models/basket-item.ts
@@ -16,6 +16,7 @@ export class BasketItem {
   private readonly adjustedSalePriceInShopperCurrency: Amount;
   private readonly adjustmentAmountInShopperCurrency: Amount;
   private readonly feeInShopperCurrency: Amount | null;
+  private readonly deliveryFeeInShopperCurrency: Amount | null;
   private readonly date: Date;
   private readonly rawDate: string;
   private readonly seats: ReservationSeat[];
@@ -38,6 +39,7 @@ export class BasketItem {
       salePriceInShopperCurrency,
       adjustmentAmountInShopperCurrency,
       feeInShopperCurrency,
+      deliveryFeeInShopperCurrency,
       date,
       items,
       venueId,
@@ -55,6 +57,7 @@ export class BasketItem {
     this.salePriceInShopperCurrency = salePriceInShopperCurrency;
     this.adjustmentAmountInShopperCurrency = adjustmentAmountInShopperCurrency;
     this.feeInShopperCurrency = feeInShopperCurrency;
+    this.deliveryFeeInShopperCurrency = deliveryFeeInShopperCurrency;
     this.date = date ? new Date(date) : null;
     this.rawDate = date;
     this.seats = items || seats;
@@ -122,6 +125,10 @@ export class BasketItem {
     return this.feeInShopperCurrency;
   }
 
+  getDeliveryFee () {
+    return this.deliveryFeeInShopperCurrency;
+  }
+
   getFaceValueAmount () {
     return this.faceValueInShopperCurrency ? this.faceValueInShopperCurrency.value : null;
   }
@@ -138,6 +145,18 @@ export class BasketItem {
     return this.feeInShopperCurrency ? this.feeInShopperCurrency.value : null;
   }
 
+  getDeliveryAmount () {
+    return this.deliveryFeeInShopperCurrency ? this.deliveryFeeInShopperCurrency.value : null;
+  }
+
+  getSalePriceWithoutDeliveryFee () {
+    return this.getOriginalSalePriceAmount() - this.getDeliveryAmount();
+  }
+
+  getSalePriceWithoutFees () {
+    return this.getSalePriceWithoutDeliveryFee() - this.getFeeAmount();
+  }
+
   hasDiscount () {
     const faceValueAmount = this.getFaceValueAmount();
 
@@ -145,7 +164,17 @@ export class BasketItem {
       return false;
     }
 
-    return faceValueAmount > this.getOriginalSalePriceAmount();
+    return faceValueAmount > this.getSalePriceWithoutDeliveryFee();
+  }
+
+  hasDiscountWithoutFees () {
+    const faceValueAmount = this.getFaceValueAmount();
+
+    if (!faceValueAmount) {
+      return false;
+    }
+
+    return faceValueAmount > this.getSalePriceWithoutFees();
   }
 
   getPromotionDiscount () {
@@ -160,7 +189,15 @@ export class BasketItem {
     const hasDiscount = this.hasDiscount();
 
     return hasDiscount
-      ? this.quantity * (this.getFaceValueAmount() - this.getOriginalSalePriceAmount())
+      ? this.quantity * (this.getFaceValueAmount() - this.getSalePriceWithoutDeliveryFee())
+      : 0;
+  }
+
+  getDiscountWithoutFees () {
+    const hasDiscount = this.hasDiscountWithoutFees();
+
+    return hasDiscount
+      ? this.quantity * (this.getFaceValueAmount() - this.getSalePriceWithoutFees())
       : 0;
   }
 
@@ -170,6 +207,14 @@ export class BasketItem {
 
   getTotalPriceWithoutPromotion () {
     return this.quantity * this.getOriginalSalePriceAmount();
+  }
+
+  getTotalPriceWithoutDeliveryFee() {
+    return this.quantity * this.getSalePriceWithoutDeliveryFee();
+  }
+
+  getTotalPriceWithoutFees() {
+    return this.quantity * this.getSalePriceWithoutFees();
   }
 
   getPriceBeforeDiscount () {

--- a/src/basket-service/models/basket-item.ts
+++ b/src/basket-service/models/basket-item.ts
@@ -145,16 +145,16 @@ export class BasketItem {
     return this.feeInShopperCurrency ? this.feeInShopperCurrency.value : null;
   }
 
-  getDeliveryAmount () {
+  getDeliveryFeeAmount () {
     return this.deliveryFeeInShopperCurrency ? this.deliveryFeeInShopperCurrency.value : null;
   }
 
-  getSalePriceWithoutDeliveryFee () {
-    return this.getOriginalSalePriceAmount() - this.getDeliveryAmount();
+  getSalePriceAmountWithoutDeliveryFee () {
+    return this.getOriginalSalePriceAmount() - this.getDeliveryFeeAmount();
   }
 
-  getSalePriceWithoutFees () {
-    return this.getSalePriceWithoutDeliveryFee() - this.getFeeAmount();
+  getSalePriceAmountWithoutFees () {
+    return this.getSalePriceAmountWithoutDeliveryFee() - this.getFeeAmount();
   }
 
   hasDiscount () {
@@ -164,7 +164,7 @@ export class BasketItem {
       return false;
     }
 
-    return faceValueAmount > this.getSalePriceWithoutDeliveryFee();
+    return faceValueAmount > this.getSalePriceAmountWithoutDeliveryFee();
   }
 
   hasDiscountWithoutFees () {
@@ -174,7 +174,7 @@ export class BasketItem {
       return false;
     }
 
-    return faceValueAmount > this.getSalePriceWithoutFees();
+    return faceValueAmount > this.getSalePriceAmountWithoutFees();
   }
 
   getPromotionDiscount () {
@@ -189,7 +189,7 @@ export class BasketItem {
     const hasDiscount = this.hasDiscount();
 
     return hasDiscount
-      ? this.quantity * (this.getFaceValueAmount() - this.getSalePriceWithoutDeliveryFee())
+      ? this.quantity * (this.getFaceValueAmount() - this.getSalePriceAmountWithoutDeliveryFee())
       : 0;
   }
 
@@ -197,7 +197,7 @@ export class BasketItem {
     const hasDiscount = this.hasDiscountWithoutFees();
 
     return hasDiscount
-      ? this.quantity * (this.getFaceValueAmount() - this.getSalePriceWithoutFees())
+      ? this.quantity * (this.getFaceValueAmount() - this.getSalePriceAmountWithoutFees())
       : 0;
   }
 
@@ -209,12 +209,12 @@ export class BasketItem {
     return this.quantity * this.getOriginalSalePriceAmount();
   }
 
-  getTotalPriceWithoutDeliveryFee() {
-    return this.quantity * this.getSalePriceWithoutDeliveryFee();
+  getTotalPriceWithoutDeliveryFee () {
+    return this.quantity * this.getSalePriceAmountWithoutDeliveryFee();
   }
 
-  getTotalPriceWithoutFees() {
-    return this.quantity * this.getSalePriceWithoutFees();
+  getTotalPriceWithoutFees () {
+    return this.quantity * this.getSalePriceAmountWithoutFees();
   }
 
   getPriceBeforeDiscount () {

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -51,6 +51,7 @@ export interface BasketItemData {
   faceValueInShopperCurrency: Amount | null;
   adjustmentAmountInShopperCurrency: Amount;
   feeInShopperCurrency: Amount | null;
+  deliveryFeeInShopperCurrency: Amount | null;
   linkedReservationId?: number;
   seats?: ReservationSeat[];
 }
@@ -124,6 +125,7 @@ export interface RequestBasketItemData {
   adjustmentAmountInShopperCurrency?: Amount;
   salePriceInShopperCurrency?: Amount;
   feeInShopperCurrency?: Amount | null;
+  deliveryFeeInShopperCurrency?: Amount | null;
 }
 
 export interface RequestBasketData {


### PR DESCRIPTION
## What are the relevant tasks?
https://app.shortcut.com/todaytix/story/47643/render-pricing-info-appropriately-for-locations-that-don-t-include-fees

## What does this PR do & what background information is important for this PR?
This PR updates and adds new methods to the basket item class that calculate various list prices including and excluding service fee and delivery fee from the original sale price, to be used in basket_fe. This will help reduce the amount of calculations done in the frontend as well as eliminate the need to pass fees data props across many different components. The new methods will support all show locations, whether they include fees directly into the sale prices or not. 

## Checklist
- [x] Updated documentation (if required, see README.md)
- [x] Ran locally: `npm run lint && npm run test-coverage`