### PR TITLE
[SC-49999] Add pubId in basket response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -6,7 +6,7 @@ export enum DeliveryMethod {
   Eticket = 'eticket',
   Evoucher = 'evoucher',
   PrintBoxOffice = 'print_box_office',
-  HandDelivered = 'hand_delivered', 
+  HandDelivered = 'hand_delivered',
   DelayedBarcode = 'delayed_barcode',
   Streaming = 'streaming',
   Supplier = 'supplier',
@@ -100,6 +100,7 @@ export interface BasketData {
   allowFlexiTickets?: boolean;
   paymentCaptureType?: string;
   location?: LocationSimpleData;
+  pubId?: string;
 }
 
 interface RequestSeat {


### PR DESCRIPTION
## What are the relevant tasks?
[SC-49999](https://app.shortcut.com/todaytix/story/49999/client-side-identify-on-services)

## What does this PR do & what background information is important for this PR?
- Adds `pubId` to the basket model returned by basket BE.
- Depends on TodayTix/basket_be#173

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [x] Ran locally: `npm run lint && npm run test-coverage`