### PR TITLE
fix(headers): sc-50871 add x-tt-affiliate-id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.29.1",
+  "version": "1.30.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/shared/typings/index.ts
+++ b/src/shared/typings/index.ts
@@ -43,6 +43,7 @@ export interface ApiPricingValue {
 }
 
 export interface SourceInformation {
+  affiliateId?: string;
   sourceName?: string;
   viewName?: string;
   sourceVersion?: string;

--- a/src/utils/__tests__/additional-headers.spec.ts
+++ b/src/utils/__tests__/additional-headers.spec.ts
@@ -3,6 +3,7 @@ import { getAdditionalHeaders } from '../additional-headers';
 const sourceName = 'Source name';
 const sourceVersion = 'v1';
 const viewName = 'View name';
+const affiliateId = 'mockretailer';
 
 describe('getAdditionalHeaders function', () => {
   it('should return right headers', () => {
@@ -27,6 +28,15 @@ describe('getAdditionalHeaders function', () => {
     };
 
     expect(getAdditionalHeaders({ sourceName, viewName })).toEqual(result);
+  });
+
+  it('should return right headers for affiliateId', () => {
+    const result = {
+      'x-ttg-client': 'JS SDK',
+      'x-tt-affiliate-id': affiliateId,
+    };
+
+    expect(getAdditionalHeaders({ affiliateId })).toEqual(result);
   });
 
   it('should return right headers when all arguments were provided', () => {

--- a/src/utils/__tests__/additional-headers.spec.ts
+++ b/src/utils/__tests__/additional-headers.spec.ts
@@ -33,7 +33,7 @@ describe('getAdditionalHeaders function', () => {
   it('should return right headers for affiliateId', () => {
     const result = {
       'x-ttg-client': 'JS SDK',
-      'x-tt-affiliate-id': affiliateId,
+      'affiliateId': affiliateId,
     };
 
     expect(getAdditionalHeaders({ affiliateId })).toEqual(result);

--- a/src/utils/additional-headers.ts
+++ b/src/utils/additional-headers.ts
@@ -4,6 +4,7 @@ export const getAdditionalHeaders = ({
   sourceName,
   sourceVersion,
   viewName,
+  affiliateId,
 }: SourceInformation = {}) => {
   const sourceNamePart = sourceName ? `${sourceName} | ` : '';
   const viewNamePart = viewName ? `${viewName} using ` : '';
@@ -20,6 +21,10 @@ export const getAdditionalHeaders = ({
 
   if (anonymousId) {
     header['x-tt-anonymous-id'] = anonymousId
+  }
+
+  if (affiliateId) {
+    header['x-tt-affiliate-id'] = affiliateId
   }
 
   return header;

--- a/src/utils/additional-headers.ts
+++ b/src/utils/additional-headers.ts
@@ -24,7 +24,7 @@ export const getAdditionalHeaders = ({
   }
 
   if (affiliateId) {
-    header['x-tt-affiliate-id'] = affiliateId
+    header['affiliateId'] = affiliateId
   }
 
   return header;


### PR DESCRIPTION
## What are the relevant tasks?
https://app.shortcut.com/todaytix/story/50871/content-service-v1-products-productid-for-nytg-returns-content-service-v3-data

## What does this PR do & what background information is important for this PR?
Adds affiliate id header to api calls

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [ ] Ran locally: `npm run lint && npm run test-coverage`