### PR TITLE
fix(products): sc-50871 include poster image on product interface

### DIFF
--- a/src/__mocks__/product-data.ts
+++ b/src/__mocks__/product-data.ts
@@ -26,4 +26,5 @@ export const apiProductDataMock = {
     },
   },
   showFaceValue: false,
+  posterImageUrl: 'http://cdn.media.tix/1',
 };

--- a/src/content-service/models/__tests__/product.spec.ts
+++ b/src/content-service/models/__tests__/product.spec.ts
@@ -55,6 +55,20 @@ describe('Product model', () => {
     });
   });
 
+  describe('getPosterImage function', () => {
+    it('should get product posterimage', () => {
+      const product = getProduct();
+
+      expect(product.getPosterImageUrl()).toEqual(apiProductDataMock.posterImageUrl);
+    });
+
+    it('should return null if poster imageUrl is not defined', () => {
+      const product = getProduct({ posterImageUrl: null });
+
+      expect(product.getPosterImageUrl()).toBeNull();
+    });
+  });
+
   describe('needShowFaceValue function', () => {
     it('should check that product should show face value', () => {
       const product = getProduct();

--- a/src/content-service/models/product.ts
+++ b/src/content-service/models/product.ts
@@ -11,6 +11,7 @@ export class Product {
   private readonly showType: ShowType;
   private readonly venue: Venue;
   private readonly showFaceValue: boolean;
+  private readonly posterImageUrl: string;
 
   constructor (productData: ApiProductData) {
     checkRequiredProperty(productData, 'Product: product data');
@@ -21,12 +22,14 @@ export class Product {
       venue,
       id,
       showFaceValue,
+      posterImageUrl,
     } = productData;
     this.name = name;
     this.showType = showType ? new ShowType(showType) : null;
     this.venue = venue ? new Venue(venue) : null;
     this.id = id;
     this.showFaceValue = showFaceValue;
+    this.posterImageUrl = posterImageUrl;
   }
 
   getId () {
@@ -43,6 +46,10 @@ export class Product {
 
   getVenue () {
     return this.venue;
+  }
+  
+  getPosterImageUrl () {
+    return this.posterImageUrl;
   }
 
   needShowFaceValue () {

--- a/src/content-service/typings/index.ts
+++ b/src/content-service/typings/index.ts
@@ -16,6 +16,7 @@ export interface ApiProductData {
   showType: ApiShowTypeData;
   venue: ApiVenueData;
   showFaceValue: boolean;
+  posterImageUrl?: string;
 }
 
 export interface ApiRegionData {


### PR DESCRIPTION
## What are the relevant tasks?
https://app.shortcut.com/todaytix/story/50871/content-service-v1-products-productid-for-nytg-returns-content-service-v3-data

## What does this PR do & what background information is important for this PR?

Adds posterImageUrl to Product interface in order to pass content V3 images and use them on `_fe`.

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [x] Ran locally: `npm run lint && npm run test-coverage`