### PR TITLE
[sc-50436] Pass anonymous ID to platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.29.0",
+  "version": "1.30.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/utils/__tests__/additional-headers.spec.ts
+++ b/src/utils/__tests__/additional-headers.spec.ts
@@ -51,4 +51,12 @@ describe('getAdditionalHeaders function', () => {
 
     expect(getAdditionalHeaders({ sourceName, sourceVersion, viewName })).toEqual(result);
   });
+
+  it('should remove quotes from anonymous id before setting the header', () => {
+    localStorage.setItem('ajs_anonymous_id', '"anonymous"')
+
+    const headers = getAdditionalHeaders({ sourceName, sourceVersion, viewName })
+
+    expect(headers['x-tt-anonymous-id']).toEqual('anonymous');
+  });
 })

--- a/src/utils/additional-headers.ts
+++ b/src/utils/additional-headers.ts
@@ -31,5 +31,5 @@ export const getAdditionalHeaders = ({
 }
 
 export const getAnonymousId = () => {
-  return localStorage.getItem('ajs_anonymous_id');
+  return localStorage.getItem('ajs_anonymous_id')?.replace(/"/g, '');
 }


### PR DESCRIPTION
## What are the relevant tasks?
[sc-50436](https://app.shortcut.com/todaytix/story/50436/venue-fe-pass-anonymousid-to-platform)

## What does this PR do & what background information is important for this PR?
Removes quotes when pulling the anonymous ID from localStorage, before sending it in request headers.

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [x] Ran locally: `npm run lint && npm run test-coverage`
- [x] Bumped version on package.json