### PR TITLE
[sc-59930] Add orderFee field to Basket

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ trim_trailing_whitespace = false
 [*.{json,yml}]
 indent_size = 2
 indent_style = space
+
+[*.ts]
+quote_type = single

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/basket-service/__mocks__/basket.ts
+++ b/src/basket-service/__mocks__/basket.ts
@@ -16,8 +16,10 @@ export const basketDataMock = {
       value: 10,
       currency: 'GBP',
     },
-    prePurchaseText: 'Your tickets will be available at the box office when you arrive for the show.',
-    postPurchaseText: 'Tickets will be held for {name} at the box office 30 minutes prior to showtime.'
+    prePurchaseText:
+      'Your tickets will be available at the box office when you arrive for the show.',
+    postPurchaseText:
+      'Tickets will be held for {name} at the box office 30 minutes prior to showtime.',
   },
   allowFlexiTickets: true,
   status: BasketStatus.Active,
@@ -27,6 +29,10 @@ export const basketDataMock = {
     { ...basketItemDataMock, id: '1' },
     { ...basketItemDataMock, id: '2' },
   ],
+  orderFee: {
+    value: 10,
+    currency: 'GBP',
+  },
   coupon: {
     code: 'SAMPLE_SOURCE_CODE',
   },
@@ -41,7 +47,7 @@ export const basketDataMock = {
     id: '2',
     includeFees: true,
     name: 'London',
-    regionCode: 'GB'
+    regionCode: 'GB',
   },
   paymentCaptureType: 'IMMEDIATE',
 };

--- a/src/basket-service/models/__tests__/basket.spec.ts
+++ b/src/basket-service/models/__tests__/basket.spec.ts
@@ -1,18 +1,13 @@
 import moment from 'moment';
 import { Basket } from '../basket';
 import { BasketItemsCollection } from '../basket-items-collection';
-import {
-  BasketItemData,
-  BasketStatus,
-  DeliveryMethod,
-  ProductType,
-} from '../../typings';
+import { BasketItemData, BasketStatus, DeliveryMethod, ProductType } from '../../typings';
 import { Delivery } from '../delivery';
 import { basketDataMock, basketItemDataMock } from '../../__mocks__';
 
 const getDeliveriesData = jest.fn().mockImplementation(() => ({}));
 jest.mock('../../services', () => ({
-  getBasketService: () => ({ getDeliveries: getDeliveriesData }),
+  getBasketService: () => ({ getDeliveries: getDeliveriesData })
 }));
 
 jest.mock('../../services/basket-details-repository-provider', () => ({
@@ -23,8 +18,7 @@ jest.mock('../../services/basket-details-repository-provider', () => ({
 
 const basketItemsData = basketDataMock.reservations;
 const getBasket = (basketItems?: BasketItemData[]) => {
-  basketDataMock.reservations =
-    typeof basketItems === 'undefined' ? basketItemsData : basketItems;
+  basketDataMock.reservations = typeof basketItems === 'undefined' ? basketItemsData : basketItems;
 
   return new Basket({ ...basketDataMock });
 };
@@ -37,17 +31,13 @@ describe('Basket', () => {
 
   describe('constructor', () => {
     it('should throw an error if reservations are not defined', () => {
-      expect(() => getBasket(null)).toThrowError(
-        'Basket: there are not reservations in the basket data'
-      );
+      expect(() => getBasket(null)).toThrowError('Basket: there are not reservations in the basket data');
     });
   });
 
   describe('getExpiredDate function', () => {
     it('should return expiration date', () => {
-      expect(getBasket().getExpiredDate()).toEqual(
-        moment(basketDataMock.expiredAt)
-      );
+      expect(getBasket().getExpiredDate()).toEqual(moment(basketDataMock.expiredAt));
     });
   });
 
@@ -56,14 +46,10 @@ describe('Basket', () => {
       const basket = getBasket();
       const basketDataMockWithExpiredStatus = basketDataMock;
       basketDataMockWithExpiredStatus.status = BasketStatus.Expired;
-      const basketWithExpiredStatus = new Basket(
-        basketDataMockWithExpiredStatus
-      );
+      const basketWithExpiredStatus = new Basket(basketDataMockWithExpiredStatus);
 
       const basketDataMockWithExpiredDate = basketDataMock;
-      basketDataMockWithExpiredDate.expiredAt = new Date(
-        '2000 01 01'
-      ).toString();
+      basketDataMockWithExpiredDate.expiredAt = new Date('2000 01 01').toString();
       const basketWithExpiredDate = new Basket(basketDataMockWithExpiredDate);
 
       expect(basket.isExpired()).toBe(false);
@@ -77,9 +63,7 @@ describe('Basket', () => {
       const basket = getBasket();
       const basketDataMockWithExpiredStatus = basketDataMock;
       basketDataMockWithExpiredStatus.status = BasketStatus.Confirmed;
-      const basketWithExpiredStatus = new Basket(
-        basketDataMockWithExpiredStatus
-      );
+      const basketWithExpiredStatus = new Basket(basketDataMockWithExpiredStatus);
 
       expect(basket.isPaid()).toBe(false);
       expect(basketWithExpiredStatus.isPaid()).toBe(true);
@@ -101,9 +85,7 @@ describe('Basket', () => {
       const basket = getBasket();
       const basketDataMockWithExpiredStatus = basketDataMock;
       basketDataMockWithExpiredStatus.status = BasketStatus.Cancelled;
-      const basketWithExpiredStatus = new Basket(
-        basketDataMockWithExpiredStatus
-      );
+      const basketWithExpiredStatus = new Basket(basketDataMockWithExpiredStatus);
 
       expect(basket.isCancelled()).toBe(false);
       expect(basketWithExpiredStatus.isCancelled()).toBe(true);
@@ -119,14 +101,12 @@ describe('Basket', () => {
 
       expect(basket.isPaymentCaptureDeferred()).toBe(false);
       expect(basketWithPending.isPaymentCaptureDeferred()).toBe(true);
-    });
-  });
+    })
+  })
 
   describe('getOrderConfirmationNumber function', () => {
     it('should return basket reference', () => {
-      expect(getBasket().getOrderConfirmationNumber()).toEqual(
-        basketDataMock.orderConfirmationNumber
-      );
+      expect(getBasket().getOrderConfirmationNumber()).toEqual(basketDataMock.orderConfirmationNumber);
     });
   });
 
@@ -144,9 +124,7 @@ describe('Basket', () => {
 
   describe('getItemsCollection function', () => {
     it('should return items collection', () => {
-      expect(getBasket().getItemsCollection()).toEqual(
-        new BasketItemsCollection(basketItemsData)
-      );
+      expect(getBasket().getItemsCollection()).toEqual(new BasketItemsCollection(basketItemsData));
     });
   });
 
@@ -171,10 +149,7 @@ describe('Basket', () => {
     it('should set delivery option', () => {
       const basket = getBasket();
 
-      const newDelivery = {
-        ...basketDataMock.delivery,
-        method: DeliveryMethod.Postage,
-      };
+      const newDelivery = { ...basketDataMock.delivery, method: DeliveryMethod.Postage };
       basket.setChosenDelivery(newDelivery);
 
       expect(basket.getChosenDelivery()).toEqual(newDelivery);
@@ -197,7 +172,7 @@ describe('Basket', () => {
       expect(getDeliveriesData).toHaveBeenCalledWith(
         basketDataMock.reference,
         new BasketItemsCollection(basketDataMock.reservations),
-        basketDataMock.channelId
+        basketDataMock.channelId,
       );
     });
 
@@ -224,12 +199,6 @@ describe('Basket', () => {
     it('should get if basket is empty', () => {
       expect(getBasket().isEmpty()).toBe(false);
       expect(getBasket([]).isEmpty()).toBe(true);
-    });
-  });
-
-  describe('getOrderFee function', () => {
-    it('should get order fee price', () => {
-      expect(getBasket().getOrderFee().value).toBe(10);
     });
   });
 
@@ -263,6 +232,12 @@ describe('Basket', () => {
     });
   });
 
+  describe('getOrderFee function', () => {
+    it('should get order fee price', () => {
+      expect(getBasket().getOrderFee().value).toBe(10);
+    });
+  });
+
   describe('hasDiscount function', () => {
     it('should get if basket has discount', () => {
       expect(getBasket().hasDiscount()).toBe(true);
@@ -279,13 +254,7 @@ describe('Basket', () => {
   describe('getUKShows function', () => {
     it('should return tickets for UK shows', async () => {
       const basket = getBasket();
-      basket
-        .getItemsCollection()
-        .getTickets()
-        .map(
-          (item) =>
-            ((item.getCountryCode as any) = () => Promise.resolve('GBR'))
-        );
+      basket.getItemsCollection().getTickets().map(item => (item.getCountryCode as any) = () => Promise.resolve('GBR'));
       const ukShows = await basket.getUKShows();
 
       expect(ukShows.length).toBe(2);
@@ -295,13 +264,7 @@ describe('Basket', () => {
   describe('getUSShows function', () => {
     it('should return tickets for US shows', async () => {
       const basket = getBasket();
-      basket
-        .getItemsCollection()
-        .getTickets()
-        .map(
-          (item) =>
-            ((item.getCountryCode as any) = () => Promise.resolve('USA'))
-        );
+      basket.getItemsCollection().getTickets().map(item => (item.getCountryCode as any) = () => Promise.resolve('USA'));
       const usShows = await basket.getUSShows();
 
       expect(usShows.length).toBe(2);
@@ -311,17 +274,13 @@ describe('Basket', () => {
   describe('isMixedBasket function', () => {
     it('should check that basket has mixed tickets', () => {
       expect(getBasket().isMixedBasket()).toBe(false);
-      expect(
-        new Basket({ ...basketDataMock, mixed: true }).isMixedBasket()
-      ).toBe(true);
+      expect(new Basket({ ...basketDataMock, mixed: true }).isMixedBasket()).toBe(true);
     });
   });
 
   describe('getAppliedPromotion function', () => {
     it('should return applied promotion', () => {
-      expect(getBasket().getAppliedPromotion()).toBe(
-        basketDataMock.appliedPromotion
-      );
+      expect(getBasket().getAppliedPromotion()).toBe(basketDataMock.appliedPromotion);
     });
   });
 
@@ -330,9 +289,7 @@ describe('Basket', () => {
       const missedPromotions = [basketDataMock.appliedPromotion];
 
       expect(getBasket().getMissedPromotion()).toBeUndefined();
-      expect(
-        new Basket({ ...basketDataMock, missedPromotions }).getMissedPromotion()
-      ).toBe(missedPromotions);
+      expect(new Basket({ ...basketDataMock, missedPromotions }).getMissedPromotion()).toBe(missedPromotions);
     });
   });
 
@@ -345,30 +302,21 @@ describe('Basket', () => {
   describe('hasCouponForPromotion function', () => {
     it('should check that coupon for promotion is set', () => {
       expect(getBasket().hasCouponForPromotion()).toBe(true);
-      expect(
-        new Basket({ ...basketDataMock, coupon: null }).hasCouponForPromotion()
-      ).toBe(false);
+      expect(new Basket({ ...basketDataMock, coupon: null }).hasCouponForPromotion()).toBe(false);
     });
   });
 
   describe('hasAppliedPromotion function', () => {
     it('should check that promotion was applied', () => {
       expect(getBasket().hasAppliedPromotion()).toBe(true);
-      expect(
-        new Basket({
-          ...basketDataMock,
-          appliedPromotion: null,
-        }).hasAppliedPromotion()
-      ).toBe(false);
+      expect(new Basket({ ...basketDataMock, appliedPromotion: null }).hasAppliedPromotion()).toBe(false);
     });
   });
 
   describe('getPromotionCode function', () => {
     it('should return promotion code', () => {
       expect(getBasket().getPromotionCode()).toBe(basketDataMock.coupon.code);
-      expect(
-        new Basket({ ...basketDataMock, coupon: null }).getPromotionCode()
-      ).toEqual('');
+      expect(new Basket({ ...basketDataMock, coupon: null }).getPromotionCode()).toEqual('');
     });
   });
 
@@ -418,9 +366,7 @@ describe('Basket', () => {
     });
 
     it('should ignore tickets without seats', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(
-        JSON.stringify(basketItemsData)
-      );
+      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
       basketItemsWithTicketWithoutSeats[0].items = null;
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
 
@@ -438,46 +384,33 @@ describe('Basket', () => {
     });
 
     it('should return ticket with upsell products', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(
-        JSON.stringify(basketItemsData)
-      );
-      basketItemsWithTicketWithoutSeats[1].productType =
-        ProductType.Flexitickets;
+      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
+      basketItemsWithTicketWithoutSeats[1].productType = ProductType.Flexitickets;
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
       const upsellProductsData = {
-        '1': [
-          {
-            aggregateReference: basketItemsData[0].items[0].aggregateReference,
-            productType: ProductType.Flexitickets,
-          },
-        ],
+        '1': [{
+          aggregateReference: basketItemsData[0].items[0].aggregateReference,
+          productType: ProductType.Flexitickets,
+        }],
       };
 
-      expect(basket.prepareBasketData(upsellProductsData).reservations).toEqual(
-        [
-          {
-            venueId: '199',
-            productId: '1001',
-            date: '2020-01-01T19:30:00+02:00',
-            quantity: 10,
-            items: basketItemDataMock.items,
-            flexiItems: [
-              {
-                aggregateReference:
-                  basketItemsData[0].items[0].aggregateReference,
-              },
-            ],
-          },
-        ]
-      );
+      expect(basket.prepareBasketData(upsellProductsData).reservations).toEqual([
+        {
+          venueId: '199',
+          productId: '1001',
+          date: '2020-01-01T19:30:00+02:00',
+          quantity: 10,
+          items: basketItemDataMock.items,
+          flexiItems: [{
+            aggregateReference: basketItemsData[0].items[0].aggregateReference,
+          }],
+        },
+      ]);
     });
 
     it('should return ticket with linked flexiticket', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(
-        JSON.stringify(basketItemsData)
-      );
-      basketItemsWithTicketWithoutSeats[1].productType =
-        ProductType.Flexitickets;
+      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
+      basketItemsWithTicketWithoutSeats[1].productType = ProductType.Flexitickets;
       basketItemsWithTicketWithoutSeats[1].linkedReservationId = '1';
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
 
@@ -488,22 +421,16 @@ describe('Basket', () => {
           date: '2020-01-01T19:30:00+02:00',
           quantity: 10,
           items: basketItemDataMock.items,
-          flexiItems: [
-            {
-              aggregateReference:
-                basketItemsData[1].items[0].aggregateReference,
-            },
-          ],
+          flexiItems: [{
+            aggregateReference: basketItemsData[1].items[0].aggregateReference,
+          }],
         },
       ]);
     });
 
     it('should return ticket only if flexiticket is not linked', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(
-        JSON.stringify(basketItemsData)
-      );
-      basketItemsWithTicketWithoutSeats[1].productType =
-        ProductType.Flexitickets;
+      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
+      basketItemsWithTicketWithoutSeats[1].productType = ProductType.Flexitickets;
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
 
       expect(basket.prepareBasketData().reservations).toEqual([
@@ -514,16 +441,13 @@ describe('Basket', () => {
           quantity: 10,
           items: basketItemDataMock.items,
           flexiItems: [],
-        },
+        }
       ]);
     });
 
     it('should return ticket without reference if flexiticket is linked but does not have items', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(
-        JSON.stringify(basketItemsData)
-      );
-      basketItemsWithTicketWithoutSeats[1].productType =
-        ProductType.Flexitickets;
+      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
+      basketItemsWithTicketWithoutSeats[1].productType = ProductType.Flexitickets;
       basketItemsWithTicketWithoutSeats[1].linkedReservationId = '1';
       basketItemsWithTicketWithoutSeats[1].items = null;
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
@@ -536,7 +460,7 @@ describe('Basket', () => {
           quantity: 10,
           items: basketItemDataMock.items,
           flexiItems: [],
-        },
+        }
       ]);
     });
   });
@@ -551,16 +475,10 @@ describe('Basket', () => {
         items: basketItemDataMock.items,
       };
 
-      expect(
-        getBasket().replaceBasketData([
-          { ...basketItemDataMock, ...newBasketItem },
-        ]).reservations
-      ).toEqual([
-        {
-          ...newBasketItem,
-          flexiItems: [],
-        },
-      ]);
+      expect(getBasket().replaceBasketData([{ ...basketItemDataMock, ...newBasketItem }]).reservations).toEqual([{
+        ...newBasketItem,
+        flexiItems: [],
+      }]);
     });
   });
 });

--- a/src/basket-service/models/__tests__/basket.spec.ts
+++ b/src/basket-service/models/__tests__/basket.spec.ts
@@ -1,13 +1,18 @@
 import moment from 'moment';
 import { Basket } from '../basket';
 import { BasketItemsCollection } from '../basket-items-collection';
-import { BasketItemData, BasketStatus, DeliveryMethod, ProductType } from '../../typings';
+import {
+  BasketItemData,
+  BasketStatus,
+  DeliveryMethod,
+  ProductType,
+} from '../../typings';
 import { Delivery } from '../delivery';
 import { basketDataMock, basketItemDataMock } from '../../__mocks__';
 
 const getDeliveriesData = jest.fn().mockImplementation(() => ({}));
 jest.mock('../../services', () => ({
-  getBasketService: () => ({ getDeliveries: getDeliveriesData })
+  getBasketService: () => ({ getDeliveries: getDeliveriesData }),
 }));
 
 jest.mock('../../services/basket-details-repository-provider', () => ({
@@ -18,7 +23,8 @@ jest.mock('../../services/basket-details-repository-provider', () => ({
 
 const basketItemsData = basketDataMock.reservations;
 const getBasket = (basketItems?: BasketItemData[]) => {
-  basketDataMock.reservations = typeof basketItems === 'undefined' ? basketItemsData : basketItems;
+  basketDataMock.reservations =
+    typeof basketItems === 'undefined' ? basketItemsData : basketItems;
 
   return new Basket({ ...basketDataMock });
 };
@@ -31,13 +37,17 @@ describe('Basket', () => {
 
   describe('constructor', () => {
     it('should throw an error if reservations are not defined', () => {
-      expect(() => getBasket(null)).toThrowError('Basket: there are not reservations in the basket data');
+      expect(() => getBasket(null)).toThrowError(
+        'Basket: there are not reservations in the basket data'
+      );
     });
   });
 
   describe('getExpiredDate function', () => {
     it('should return expiration date', () => {
-      expect(getBasket().getExpiredDate()).toEqual(moment(basketDataMock.expiredAt));
+      expect(getBasket().getExpiredDate()).toEqual(
+        moment(basketDataMock.expiredAt)
+      );
     });
   });
 
@@ -46,10 +56,14 @@ describe('Basket', () => {
       const basket = getBasket();
       const basketDataMockWithExpiredStatus = basketDataMock;
       basketDataMockWithExpiredStatus.status = BasketStatus.Expired;
-      const basketWithExpiredStatus = new Basket(basketDataMockWithExpiredStatus);
+      const basketWithExpiredStatus = new Basket(
+        basketDataMockWithExpiredStatus
+      );
 
       const basketDataMockWithExpiredDate = basketDataMock;
-      basketDataMockWithExpiredDate.expiredAt = new Date('2000 01 01').toString();
+      basketDataMockWithExpiredDate.expiredAt = new Date(
+        '2000 01 01'
+      ).toString();
       const basketWithExpiredDate = new Basket(basketDataMockWithExpiredDate);
 
       expect(basket.isExpired()).toBe(false);
@@ -63,7 +77,9 @@ describe('Basket', () => {
       const basket = getBasket();
       const basketDataMockWithExpiredStatus = basketDataMock;
       basketDataMockWithExpiredStatus.status = BasketStatus.Confirmed;
-      const basketWithExpiredStatus = new Basket(basketDataMockWithExpiredStatus);
+      const basketWithExpiredStatus = new Basket(
+        basketDataMockWithExpiredStatus
+      );
 
       expect(basket.isPaid()).toBe(false);
       expect(basketWithExpiredStatus.isPaid()).toBe(true);
@@ -85,7 +101,9 @@ describe('Basket', () => {
       const basket = getBasket();
       const basketDataMockWithExpiredStatus = basketDataMock;
       basketDataMockWithExpiredStatus.status = BasketStatus.Cancelled;
-      const basketWithExpiredStatus = new Basket(basketDataMockWithExpiredStatus);
+      const basketWithExpiredStatus = new Basket(
+        basketDataMockWithExpiredStatus
+      );
 
       expect(basket.isCancelled()).toBe(false);
       expect(basketWithExpiredStatus.isCancelled()).toBe(true);
@@ -101,12 +119,14 @@ describe('Basket', () => {
 
       expect(basket.isPaymentCaptureDeferred()).toBe(false);
       expect(basketWithPending.isPaymentCaptureDeferred()).toBe(true);
-    })
-  })
+    });
+  });
 
   describe('getOrderConfirmationNumber function', () => {
     it('should return basket reference', () => {
-      expect(getBasket().getOrderConfirmationNumber()).toEqual(basketDataMock.orderConfirmationNumber);
+      expect(getBasket().getOrderConfirmationNumber()).toEqual(
+        basketDataMock.orderConfirmationNumber
+      );
     });
   });
 
@@ -124,7 +144,9 @@ describe('Basket', () => {
 
   describe('getItemsCollection function', () => {
     it('should return items collection', () => {
-      expect(getBasket().getItemsCollection()).toEqual(new BasketItemsCollection(basketItemsData));
+      expect(getBasket().getItemsCollection()).toEqual(
+        new BasketItemsCollection(basketItemsData)
+      );
     });
   });
 
@@ -149,7 +171,10 @@ describe('Basket', () => {
     it('should set delivery option', () => {
       const basket = getBasket();
 
-      const newDelivery = { ...basketDataMock.delivery, method: DeliveryMethod.Postage };
+      const newDelivery = {
+        ...basketDataMock.delivery,
+        method: DeliveryMethod.Postage,
+      };
       basket.setChosenDelivery(newDelivery);
 
       expect(basket.getChosenDelivery()).toEqual(newDelivery);
@@ -172,7 +197,7 @@ describe('Basket', () => {
       expect(getDeliveriesData).toHaveBeenCalledWith(
         basketDataMock.reference,
         new BasketItemsCollection(basketDataMock.reservations),
-        basketDataMock.channelId,
+        basketDataMock.channelId
       );
     });
 
@@ -199,6 +224,12 @@ describe('Basket', () => {
     it('should get if basket is empty', () => {
       expect(getBasket().isEmpty()).toBe(false);
       expect(getBasket([]).isEmpty()).toBe(true);
+    });
+  });
+
+  describe('getOrderFee function', () => {
+    it('should get order fee price', () => {
+      expect(getBasket().getOrderFee().value).toBe(10);
     });
   });
 
@@ -248,7 +279,13 @@ describe('Basket', () => {
   describe('getUKShows function', () => {
     it('should return tickets for UK shows', async () => {
       const basket = getBasket();
-      basket.getItemsCollection().getTickets().map(item => (item.getCountryCode as any) = () => Promise.resolve('GBR'));
+      basket
+        .getItemsCollection()
+        .getTickets()
+        .map(
+          (item) =>
+            ((item.getCountryCode as any) = () => Promise.resolve('GBR'))
+        );
       const ukShows = await basket.getUKShows();
 
       expect(ukShows.length).toBe(2);
@@ -258,7 +295,13 @@ describe('Basket', () => {
   describe('getUSShows function', () => {
     it('should return tickets for US shows', async () => {
       const basket = getBasket();
-      basket.getItemsCollection().getTickets().map(item => (item.getCountryCode as any) = () => Promise.resolve('USA'));
+      basket
+        .getItemsCollection()
+        .getTickets()
+        .map(
+          (item) =>
+            ((item.getCountryCode as any) = () => Promise.resolve('USA'))
+        );
       const usShows = await basket.getUSShows();
 
       expect(usShows.length).toBe(2);
@@ -268,13 +311,17 @@ describe('Basket', () => {
   describe('isMixedBasket function', () => {
     it('should check that basket has mixed tickets', () => {
       expect(getBasket().isMixedBasket()).toBe(false);
-      expect(new Basket({ ...basketDataMock, mixed: true }).isMixedBasket()).toBe(true);
+      expect(
+        new Basket({ ...basketDataMock, mixed: true }).isMixedBasket()
+      ).toBe(true);
     });
   });
 
   describe('getAppliedPromotion function', () => {
     it('should return applied promotion', () => {
-      expect(getBasket().getAppliedPromotion()).toBe(basketDataMock.appliedPromotion);
+      expect(getBasket().getAppliedPromotion()).toBe(
+        basketDataMock.appliedPromotion
+      );
     });
   });
 
@@ -283,7 +330,9 @@ describe('Basket', () => {
       const missedPromotions = [basketDataMock.appliedPromotion];
 
       expect(getBasket().getMissedPromotion()).toBeUndefined();
-      expect(new Basket({ ...basketDataMock, missedPromotions }).getMissedPromotion()).toBe(missedPromotions);
+      expect(
+        new Basket({ ...basketDataMock, missedPromotions }).getMissedPromotion()
+      ).toBe(missedPromotions);
     });
   });
 
@@ -296,21 +345,30 @@ describe('Basket', () => {
   describe('hasCouponForPromotion function', () => {
     it('should check that coupon for promotion is set', () => {
       expect(getBasket().hasCouponForPromotion()).toBe(true);
-      expect(new Basket({ ...basketDataMock, coupon: null }).hasCouponForPromotion()).toBe(false);
+      expect(
+        new Basket({ ...basketDataMock, coupon: null }).hasCouponForPromotion()
+      ).toBe(false);
     });
   });
 
   describe('hasAppliedPromotion function', () => {
     it('should check that promotion was applied', () => {
       expect(getBasket().hasAppliedPromotion()).toBe(true);
-      expect(new Basket({ ...basketDataMock, appliedPromotion: null }).hasAppliedPromotion()).toBe(false);
+      expect(
+        new Basket({
+          ...basketDataMock,
+          appliedPromotion: null,
+        }).hasAppliedPromotion()
+      ).toBe(false);
     });
   });
 
   describe('getPromotionCode function', () => {
     it('should return promotion code', () => {
       expect(getBasket().getPromotionCode()).toBe(basketDataMock.coupon.code);
-      expect(new Basket({ ...basketDataMock, coupon: null }).getPromotionCode()).toEqual('');
+      expect(
+        new Basket({ ...basketDataMock, coupon: null }).getPromotionCode()
+      ).toEqual('');
     });
   });
 
@@ -360,7 +418,9 @@ describe('Basket', () => {
     });
 
     it('should ignore tickets without seats', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
+      const basketItemsWithTicketWithoutSeats = JSON.parse(
+        JSON.stringify(basketItemsData)
+      );
       basketItemsWithTicketWithoutSeats[0].items = null;
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
 
@@ -378,33 +438,46 @@ describe('Basket', () => {
     });
 
     it('should return ticket with upsell products', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
-      basketItemsWithTicketWithoutSeats[1].productType = ProductType.Flexitickets;
+      const basketItemsWithTicketWithoutSeats = JSON.parse(
+        JSON.stringify(basketItemsData)
+      );
+      basketItemsWithTicketWithoutSeats[1].productType =
+        ProductType.Flexitickets;
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
       const upsellProductsData = {
-        '1': [{
-          aggregateReference: basketItemsData[0].items[0].aggregateReference,
-          productType: ProductType.Flexitickets,
-        }],
+        '1': [
+          {
+            aggregateReference: basketItemsData[0].items[0].aggregateReference,
+            productType: ProductType.Flexitickets,
+          },
+        ],
       };
 
-      expect(basket.prepareBasketData(upsellProductsData).reservations).toEqual([
-        {
-          venueId: '199',
-          productId: '1001',
-          date: '2020-01-01T19:30:00+02:00',
-          quantity: 10,
-          items: basketItemDataMock.items,
-          flexiItems: [{
-            aggregateReference: basketItemsData[0].items[0].aggregateReference,
-          }],
-        },
-      ]);
+      expect(basket.prepareBasketData(upsellProductsData).reservations).toEqual(
+        [
+          {
+            venueId: '199',
+            productId: '1001',
+            date: '2020-01-01T19:30:00+02:00',
+            quantity: 10,
+            items: basketItemDataMock.items,
+            flexiItems: [
+              {
+                aggregateReference:
+                  basketItemsData[0].items[0].aggregateReference,
+              },
+            ],
+          },
+        ]
+      );
     });
 
     it('should return ticket with linked flexiticket', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
-      basketItemsWithTicketWithoutSeats[1].productType = ProductType.Flexitickets;
+      const basketItemsWithTicketWithoutSeats = JSON.parse(
+        JSON.stringify(basketItemsData)
+      );
+      basketItemsWithTicketWithoutSeats[1].productType =
+        ProductType.Flexitickets;
       basketItemsWithTicketWithoutSeats[1].linkedReservationId = '1';
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
 
@@ -415,16 +488,22 @@ describe('Basket', () => {
           date: '2020-01-01T19:30:00+02:00',
           quantity: 10,
           items: basketItemDataMock.items,
-          flexiItems: [{
-            aggregateReference: basketItemsData[1].items[0].aggregateReference,
-          }],
+          flexiItems: [
+            {
+              aggregateReference:
+                basketItemsData[1].items[0].aggregateReference,
+            },
+          ],
         },
       ]);
     });
 
     it('should return ticket only if flexiticket is not linked', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
-      basketItemsWithTicketWithoutSeats[1].productType = ProductType.Flexitickets;
+      const basketItemsWithTicketWithoutSeats = JSON.parse(
+        JSON.stringify(basketItemsData)
+      );
+      basketItemsWithTicketWithoutSeats[1].productType =
+        ProductType.Flexitickets;
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
 
       expect(basket.prepareBasketData().reservations).toEqual([
@@ -435,13 +514,16 @@ describe('Basket', () => {
           quantity: 10,
           items: basketItemDataMock.items,
           flexiItems: [],
-        }
+        },
       ]);
     });
 
     it('should return ticket without reference if flexiticket is linked but does not have items', () => {
-      const basketItemsWithTicketWithoutSeats = JSON.parse(JSON.stringify(basketItemsData));
-      basketItemsWithTicketWithoutSeats[1].productType = ProductType.Flexitickets;
+      const basketItemsWithTicketWithoutSeats = JSON.parse(
+        JSON.stringify(basketItemsData)
+      );
+      basketItemsWithTicketWithoutSeats[1].productType =
+        ProductType.Flexitickets;
       basketItemsWithTicketWithoutSeats[1].linkedReservationId = '1';
       basketItemsWithTicketWithoutSeats[1].items = null;
       const basket = getBasket(basketItemsWithTicketWithoutSeats);
@@ -454,7 +536,7 @@ describe('Basket', () => {
           quantity: 10,
           items: basketItemDataMock.items,
           flexiItems: [],
-        }
+        },
       ]);
     });
   });
@@ -469,10 +551,16 @@ describe('Basket', () => {
         items: basketItemDataMock.items,
       };
 
-      expect(getBasket().replaceBasketData([{ ...basketItemDataMock, ...newBasketItem }]).reservations).toEqual([{
-        ...newBasketItem,
-        flexiItems: [],
-      }]);
+      expect(
+        getBasket().replaceBasketData([
+          { ...basketItemDataMock, ...newBasketItem },
+        ]).reservations
+      ).toEqual([
+        {
+          ...newBasketItem,
+          flexiItems: [],
+        },
+      ]);
     });
   });
 });

--- a/src/basket-service/models/basket.ts
+++ b/src/basket-service/models/basket.ts
@@ -29,7 +29,7 @@ export class Basket {
   private deliveries: Promise<Delivery[]>;
   private repository = basketDetailsRepositoryProvider.getRepository();
 
-  constructor(basketData: BasketData) {
+  constructor (basketData: BasketData) {
     checkRequiredProperty(basketData, 'Basket: basket data');
 
     this.basketData = basketData;
@@ -60,70 +60,70 @@ export class Basket {
   }
 
   // for supporting IE11
-  getExpiredDate() {
+  getExpiredDate () {
     return this.expiredAt;
   }
 
-  isExpired() {
+  isExpired () {
     return (
       this.status === BasketStatus.Expired ||
       this.getExpiredDate().valueOf() < moment().valueOf()
     );
   }
 
-  isPaid() {
+  isPaid () {
     return this.status === BasketStatus.Confirmed;
   }
 
-  isCancelled() {
+  isCancelled () {
     return this.status === BasketStatus.Cancelled;
   }
 
-  isPaymentCaptureDeferred() {
+  isPaymentCaptureDeferred () {
     return this.paymentCaptureType === PaymentCaptureType.Pending;
   }
 
-  getReference() {
+  getReference () {
     return this.reference;
   }
 
-  getOrderConfirmationNumber() {
+  getOrderConfirmationNumber () {
     return this.orderConfirmationNumber;
   }
 
-  getChecksum() {
+  getChecksum () {
     return this.checksum;
   }
 
-  getItemsCollection() {
+  getItemsCollection () {
     return this.itemsCollection;
   }
 
-  setShopperCurrency(currency: string) {
+  setShopperCurrency (currency: string) {
     checkRequiredProperty(currency, 'setShopperCurrency: currency');
 
     this.basketData.shopperCurrency = currency;
   }
 
-  getShopperCurrency() {
+  getShopperCurrency () {
     return this.basketData.shopperCurrency;
   }
 
-  setChosenDelivery(delivery: DeliveryData | null) {
+  setChosenDelivery (delivery: DeliveryData | null) {
     this.basketData.delivery = delivery;
   }
 
-  getChosenDelivery() {
+  getChosenDelivery () {
     return this.basketData.delivery;
   }
 
-  setDeliveries(deliveries: Promise<Delivery[]>) {
+  setDeliveries (deliveries: Promise<Delivery[]>) {
     checkRequiredProperty(deliveries, 'setDeliveries: promise with deliveries');
 
     this.deliveries = deliveries;
   }
 
-  async getDeliveries() {
+  async getDeliveries () {
     if (!this.deliveries) {
       this.deliveries = this.repository.getDeliveries(
         this.getReference(),
@@ -135,47 +135,47 @@ export class Basket {
     return this.deliveries;
   }
 
-  isEmpty() {
+  isEmpty () {
     return !this.itemsCollection.getLength();
   }
 
-  getTotalPrice() {
+  getTotalPrice () {
     return this.reduceBasketItemsAmount(
       (totalPrice, item) => totalPrice + item.getTotalPrice()
     );
   }
 
-  isTotalPriceZero() {
+  isTotalPriceZero () {
     return this.getTotalPrice() === 0;
   }
 
-  getTotalDiscount() {
+  getTotalDiscount () {
     return this.reduceBasketItemsAmount(
       (totalPrice, item) => totalPrice + item.getDiscount()
     );
   }
 
-  getTotalPromotionDiscount() {
+  getTotalPromotionDiscount () {
     return this.reduceBasketItemsAmount(
       (totalPrice, item) => totalPrice + item.getPromotionDiscount()
     );
   }
 
-  getTotalPriceBeforeDiscount() {
+  getTotalPriceBeforeDiscount () {
     return this.reduceBasketItemsAmount(
       (totalPrice, item) => totalPrice + item.getPriceBeforeDiscount()
     );
   }
 
-  hasDiscount() {
+  hasDiscount () {
     return this.itemsCollection.getItems().some((item) => item.hasDiscount());
   }
 
-  getBasketData() {
+  getBasketData () {
     return this.basketData;
   }
 
-  getUKShows() {
+  getUKShows () {
     const tickets = this.itemsCollection.getTickets();
     const countryCodePromises = tickets.map((ticket) =>
       ticket.getCountryCode()
@@ -188,7 +188,7 @@ export class Basket {
     });
   }
 
-  getUSShows() {
+  getUSShows () {
     const tickets = this.itemsCollection.getTickets();
     const countryCodePromises = tickets.map((ticket) =>
       ticket.getCountryCode()
@@ -201,57 +201,57 @@ export class Basket {
     });
   }
 
-  isMixedBasket() {
+  isMixedBasket () {
     return !!this.basketData.mixed;
   }
 
-  areFlexiTicketsAllowed() {
+  areFlexiTicketsAllowed () {
     return this.basketData.allowFlexiTickets;
   }
 
-  getAppliedPromotion() {
+  getAppliedPromotion () {
     return this.basketData.appliedPromotion;
   }
 
-  getMissedPromotion() {
+  getMissedPromotion () {
     return this.basketData.missedPromotions;
   }
 
-  getCouponForPromotion() {
+  getCouponForPromotion () {
     return this.basketData.coupon;
   }
 
-  hasCouponForPromotion() {
+  hasCouponForPromotion () {
     return !!this.getCouponForPromotion();
   }
 
-  hasAppliedPromotion() {
+  hasAppliedPromotion () {
     return !!this.getAppliedPromotion();
   }
 
-  getPromotionCode() {
+  getPromotionCode () {
     return this.basketData.coupon ? this.basketData.coupon.code : '';
   }
 
-  setChannelId(channelId: string) {
+  setChannelId (channelId: string) {
     checkRequiredProperty(channelId, 'setChannelId: channel id');
 
     this.basketData.channelId = channelId;
   }
 
-  getChannelId() {
+  getChannelId () {
     return this.basketData.channelId;
   }
 
-  getLocation() {
+  getLocation () {
     return this.basketData.location;
   }
 
-  getOrderFee() {
+  getOrderFee () {
     return this.orderFee;
   }
 
-  prepareBasketData(upsellProducts?: UpsellApiProductData) {
+  prepareBasketData (upsellProducts?: UpsellApiProductData) {
     const { reservations } = this.basketData;
     const itemsCollection = new BasketItemsCollection(reservations);
     const filteredReservations = itemsCollection
@@ -269,7 +269,7 @@ export class Basket {
     };
   }
 
-  replaceBasketData(basketItems: BasketItemData[]) {
+  replaceBasketData (basketItems: BasketItemData[]) {
     checkRequiredProperty(
       basketItems,
       'replaceBasketData: basket items collection'
@@ -290,7 +290,7 @@ export class Basket {
     };
   }
 
-  private prepareBasketReservation(
+  private prepareBasketReservation (
     filteredReservations: any,
     flexiTickets: BasketItem[],
     upsellProducts?: UpsellApiProductData
@@ -333,7 +333,7 @@ export class Basket {
     });
   }
 
-  private getLinkedFlexiItems(
+  private getLinkedFlexiItems (
     flexiTickets: BasketItem[],
     parentBasketItem: BasketItem
   ) {
@@ -357,7 +357,7 @@ export class Basket {
     }));
   }
 
-  private reduceBasketItemsAmount(
+  private reduceBasketItemsAmount (
     reducer: (accumulator: number, currentValue: BasketItem) => number
   ) {
     return this.itemsCollection.getItems().reduce(reducer, 0);

--- a/src/basket-service/models/basket.ts
+++ b/src/basket-service/models/basket.ts
@@ -14,7 +14,6 @@ import {
   BasketItemData,
   PaymentCaptureType,
 } from '../typings';
-import { Amount } from 'src/shared/typings';
 
 export class Basket {
   private readonly itemsCollection: BasketItemsCollection;
@@ -23,7 +22,6 @@ export class Basket {
   private readonly reference: string;
   private readonly checksum: string;
   private readonly orderConfirmationNumber: string;
-  private readonly orderFee: Amount | null;
   private readonly paymentCaptureType?: string;
   private basketData: BasketData;
   private deliveries: Promise<Delivery[]>;
@@ -41,8 +39,7 @@ export class Basket {
       reference,
       checksum,
       orderConfirmationNumber,
-      paymentCaptureType,
-      orderFee,
+      paymentCaptureType
     } = this.basketData;
 
     if (!reservations) {
@@ -55,7 +52,6 @@ export class Basket {
     this.reference = reference;
     this.checksum = checksum;
     this.orderConfirmationNumber = orderConfirmationNumber;
-    this.orderFee = orderFee;
     this.paymentCaptureType = paymentCaptureType;
   }
 
@@ -65,10 +61,7 @@ export class Basket {
   }
 
   isExpired () {
-    return (
-      this.status === BasketStatus.Expired ||
-      this.getExpiredDate().valueOf() < moment().valueOf()
-    );
+    return this.status === BasketStatus.Expired || this.getExpiredDate().valueOf() < moment().valueOf();
   }
 
   isPaid () {
@@ -80,7 +73,7 @@ export class Basket {
   }
 
   isPaymentCaptureDeferred () {
-    return this.paymentCaptureType === PaymentCaptureType.Pending;
+    return this.paymentCaptureType === PaymentCaptureType.Pending; 
   }
 
   getReference () {
@@ -128,11 +121,11 @@ export class Basket {
       this.deliveries = this.repository.getDeliveries(
         this.getReference(),
         this.getItemsCollection(),
-        this.basketData.channelId
+        this.basketData.channelId,
       );
     }
 
-    return this.deliveries;
+   return this.deliveries;
   }
 
   isEmpty () {
@@ -140,9 +133,7 @@ export class Basket {
   }
 
   getTotalPrice () {
-    return this.reduceBasketItemsAmount(
-      (totalPrice, item) => totalPrice + item.getTotalPrice()
-    );
+    return this.reduceBasketItemsAmount((totalPrice, item) => totalPrice + item.getTotalPrice());
   }
 
   isTotalPriceZero () {
@@ -150,25 +141,19 @@ export class Basket {
   }
 
   getTotalDiscount () {
-    return this.reduceBasketItemsAmount(
-      (totalPrice, item) => totalPrice + item.getDiscount()
-    );
+    return this.reduceBasketItemsAmount((totalPrice, item) => totalPrice + item.getDiscount());
   }
 
   getTotalPromotionDiscount () {
-    return this.reduceBasketItemsAmount(
-      (totalPrice, item) => totalPrice + item.getPromotionDiscount()
-    );
+    return this.reduceBasketItemsAmount((totalPrice, item) => totalPrice + item.getPromotionDiscount());
   }
 
   getTotalPriceBeforeDiscount () {
-    return this.reduceBasketItemsAmount(
-      (totalPrice, item) => totalPrice + item.getPriceBeforeDiscount()
-    );
+    return this.reduceBasketItemsAmount((totalPrice, item) => totalPrice + item.getPriceBeforeDiscount());
   }
 
   hasDiscount () {
-    return this.itemsCollection.getItems().some((item) => item.hasDiscount());
+    return this.itemsCollection.getItems().some(item => item.hasDiscount());
   }
 
   getBasketData () {
@@ -177,9 +162,7 @@ export class Basket {
 
   getUKShows () {
     const tickets = this.itemsCollection.getTickets();
-    const countryCodePromises = tickets.map((ticket) =>
-      ticket.getCountryCode()
-    );
+    const countryCodePromises = tickets.map(ticket => ticket.getCountryCode());
 
     return Promise.all(countryCodePromises).then((countryCodes) => {
       return countryCodes.filter((countryCode) => {
@@ -190,9 +173,7 @@ export class Basket {
 
   getUSShows () {
     const tickets = this.itemsCollection.getTickets();
-    const countryCodePromises = tickets.map((ticket) =>
-      ticket.getCountryCode()
-    );
+    const countryCodePromises = tickets.map(ticket => ticket.getCountryCode());
 
     return Promise.all(countryCodePromises).then((countryCodes) => {
       return countryCodes.filter((countryCode) => {
@@ -211,6 +192,10 @@ export class Basket {
 
   getAppliedPromotion () {
     return this.basketData.appliedPromotion;
+  }
+
+  getOrderFee () {
+    return this.basketData.orderFee;
   }
 
   getMissedPromotion () {
@@ -247,54 +232,32 @@ export class Basket {
     return this.basketData.location;
   }
 
-  getOrderFee () {
-    return this.orderFee;
-  }
-
   prepareBasketData (upsellProducts?: UpsellApiProductData) {
     const { reservations } = this.basketData;
     const itemsCollection = new BasketItemsCollection(reservations);
-    const filteredReservations = itemsCollection
-      .getItems()
-      .filter((basketItem) => basketItem.isTicket());
+    const filteredReservations = itemsCollection.getItems().filter(basketItem => basketItem.isTicket());
     const flexiTickets = itemsCollection.getFlexitickets();
 
     return {
       ...this.basketData,
-      reservations: this.prepareBasketReservation(
-        filteredReservations,
-        flexiTickets,
-        upsellProducts
-      ),
+      reservations: this.prepareBasketReservation(filteredReservations, flexiTickets, upsellProducts),
     };
-  }
+  };
 
   replaceBasketData (basketItems: BasketItemData[]) {
-    checkRequiredProperty(
-      basketItems,
-      'replaceBasketData: basket items collection'
-    );
+    checkRequiredProperty(basketItems, 'replaceBasketData: basket items collection');
 
     const itemsCollection = new BasketItemsCollection(basketItems);
-    const filteredReservations = itemsCollection
-      .getItems()
-      .filter((basketItem) => basketItem.isTicket());
+    const filteredReservations = itemsCollection.getItems().filter(basketItem => basketItem.isTicket());
     const flexiTickets = itemsCollection.getFlexitickets();
 
     return {
       ...this.basketData,
-      reservations: this.prepareBasketReservation(
-        filteredReservations,
-        flexiTickets
-      ),
+      reservations: this.prepareBasketReservation(filteredReservations, flexiTickets),
     };
   }
 
-  private prepareBasketReservation (
-    filteredReservations: any,
-    flexiTickets: BasketItem[],
-    upsellProducts?: UpsellApiProductData
-  ) {
+  private prepareBasketReservation (filteredReservations: any, flexiTickets: BasketItem[], upsellProducts?: UpsellApiProductData) {
     return filteredReservations.map((basketItem: BasketItem) => {
       const items = basketItem.getSeats();
 
@@ -302,22 +265,17 @@ export class Basket {
         return;
       }
 
-      items.map((item: any) => ({
-        aggregateReference: item.aggregateReference,
-      }));
+      items.map((item: any) => ({ aggregateReference: item.aggregateReference }));
       let flexiItems = [];
-      const upsellProductForItem =
-        upsellProducts && upsellProducts[basketItem.getId()];
+      const upsellProductForItem = upsellProducts && upsellProducts[basketItem.getId()];
 
       if (upsellProductForItem) {
-        const flexiTicketsForItem = upsellProductForItem.filter(
-          (upsellProduct) =>
+        const flexiTicketsForItem = upsellProductForItem
+          .filter(upsellProduct =>
             upsellProduct.productType === ProductType.Flexitickets
-        );
+          );
 
-        flexiItems = flexiTicketsForItem.map((item) => ({
-          aggregateReference: item.aggregateReference,
-        }));
+        flexiItems = flexiTicketsForItem.map(item => ({ aggregateReference: item.aggregateReference }));
       } else {
         flexiItems = this.getLinkedFlexiItems(flexiTickets, basketItem);
       }
@@ -333,33 +291,28 @@ export class Basket {
     });
   }
 
-  private getLinkedFlexiItems (
-    flexiTickets: BasketItem[],
-    parentBasketItem: BasketItem
-  ) {
-    const linkedFlexiTickets = flexiTickets.find((item) => {
-      const linkedReservationId = item.getLinkedReservationId();
-      const parentBasketItemId = parentBasketItem.getId();
+  private getLinkedFlexiItems (flexiTickets: BasketItem[], parentBasketItem: BasketItem) {
+    const linkedFlexiTickets = flexiTickets
+      .find(item => {
+        const linkedReservationId = item.getLinkedReservationId();
+        const parentBasketItemId = parentBasketItem.getId();
 
-      if (!linkedReservationId || !parentBasketItemId) {
-        return false;
-      }
+        if (!linkedReservationId || !parentBasketItemId) {
+          return false;
+        }
 
-      return linkedReservationId.toString() === parentBasketItemId.toString();
-    });
+        return linkedReservationId.toString() === parentBasketItemId.toString();
+      });
 
     if (!linkedFlexiTickets) {
       return [];
     }
 
-    return (linkedFlexiTickets.getSeats() || []).map((item: any) => ({
-      aggregateReference: item.aggregateReference,
-    }));
+    return (linkedFlexiTickets.getSeats() || [])
+      .map((item: any) => ({ aggregateReference: item.aggregateReference }));
   }
 
-  private reduceBasketItemsAmount (
-    reducer: (accumulator: number, currentValue: BasketItem) => number
-  ) {
+  private reduceBasketItemsAmount (reducer: (accumulator: number, currentValue: BasketItem) => number) {
     return this.itemsCollection.getItems().reduce(reducer, 0);
   }
 }

--- a/src/basket-service/typings/index.ts
+++ b/src/basket-service/typings/index.ts
@@ -85,6 +85,7 @@ export interface BasketData {
   reservations: BasketItemData[];
   reference?: string;
   orderConfirmationNumber?: string;
+  orderFee?: Amount;
   checksum?: string;
   delivery?: DeliveryData;
   createdAt?: string;


### PR DESCRIPTION
## What are the relevant tasks?
https://app.shortcut.com/todaytix/story/59930/order-fee-transparency-in-shared-checkout-for-web-customer-retailers

## What does this PR do & what background information is important for this PR?
Adds orderFee field to Basket and BasketData classes.

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [x] Ran locally: `npm run lint && npm run test-coverage`
- [x] Bumped version on package.json