### PR TITLE
Collect attribution cookies and send them to basket service.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.30.6",
+  "version": "1.31.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/basket-service/services/api-provider.ts
+++ b/src/basket-service/services/api-provider.ts
@@ -18,7 +18,7 @@ export const getBasketServiceApi = (
   const deliveriesPath = '/deliveryOptions';
   const applyDeliveryPath = '/applyDelivery';
   const reservationsPath = '/reservations';
-  const additionalHeaders = getAdditionalHeaders(sourceInformation);
+  const additionalHeaders = getAdditionalHeaders(sourceInformation, true);
 
   const upsertBasket = async (basketData: RequestBasketData, returnTTId: boolean = false): Promise<BasketData | ApiError> => {
     checkRequiredProperty(basketData, 'upsertBasket: basket data');

--- a/src/utils/__tests__/additional-headers.spec.ts
+++ b/src/utils/__tests__/additional-headers.spec.ts
@@ -59,4 +59,15 @@ describe('getAdditionalHeaders function', () => {
 
     expect(headers['x-tt-anonymous-id']).toEqual('anonymous');
   });
+
+  it('should fetch and attache cookie header', () => {
+    document.cookie = '_fbp=fb.1.1635882611934.721450586;'
+    document.cookie = '_ga=GA1.2.1987863969.1635949433;'
+    document.cookie = '_gcl_au=1.1.652822416.1651692668;'
+    document.cookie = '_clsk=12njzoh|1655497229922|2|1|i.clarity.ms/collect;'
+
+    const headers = getAdditionalHeaders({ sourceName, sourceVersion, viewName }, true)
+
+    expect(headers['x-ttg-cookie']).toEqual('_ga=GA1.2.1987863969.1635949433; _fbp=fb.1.1635882611934.721450586; _gcl_au=1.1.652822416.1651692668;');
+  });
 })


### PR DESCRIPTION
## What are the relevant tasks?
https://app.shortcut.com/todaytix/story/74734/non-tt-web-attribute-purchases-to-fb-google-ads

## What does this PR do & what background information is important for this PR?
Collect attribution cookies and send it to the Basket Service, so it would be possible to attribute basket segment events

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [x] Ran locally: `npm run lint && npm run test-coverage`
- [x] Bumped version on package.json