### PR TITLE
[sc-100593] Add optional checksum param to basket service methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,26 +67,25 @@ interface SourceInformation {
 * removePromoCode(basket, returnTTId, checksum) ⇒ Basket
 * clearBasket(basketReference, [channelId]) ⇒ Basket
 
-#### ➥ getBasket(reference, checksum, [channelId], returnTTId) ⇒ Basket
+#### ➥ getBasket(reference, [channelId], returnTTId, checksum) ⇒ Basket
 *Get basket by reference*
 **Returns**: Basket - *basket model*  
 
 | Param       | Type   |
 |-------------|--------|
 | reference   | string | 
-| checksum    | string |
 | [channelId] | string | 
 | returnTTId  | bool   | 
+| checksum    | string |
 
-#### ➥ createBasket(basketData, checksum, returnTTId) ⇒ Basket
+#### ➥ createBasket(basketData, returnTTId) ⇒ Basket
 *Create new basket*
 **Returns**: Basket - *basket model*  
 
 | Param      | Type              |
 |------------|-------------------|
-| basketData | RequestBasketData | 
-| checksum   | string            |
-| returnTTId | bool              | 
+| basketData | RequestBasketData |
+| returnTTId | bool              |
 
 ```typescript
 interface RequestBasketData {
@@ -146,7 +145,7 @@ enum ProductType {
 }
 ```
 
-#### ➥ getDeliveries(basketReference, basketItems, checksum, [channelId]) ⇒ Array&lt;Delivery&gt;
+#### ➥ getDeliveries(basketReference, basketItems, [channelId], checksum) ⇒ Array&lt;Delivery&gt;
 *Get delivery options available for basket*
 **Returns**: Array&lt;Delivery&gt; - *delivery models*  
 
@@ -154,8 +153,8 @@ enum ProductType {
 | --- | --- |
 | basketReference | string | 
 | basketItems | BasketItemsCollection | 
-| checksum    | string |
 | [channelId] | string | 
+| checksum    | string |
 
 #### ➥ setSelectedDelivery(basket, selectedDelivery, checksum) ⇒ Basket
 *Set delivery option*
@@ -192,7 +191,7 @@ interface Amount {
 }
 ```
 
-#### ➥ addItems(basket, basketItems, checksum, returnTTId) ⇒ Basket
+#### ➥ addItems(basket, basketItems, returnTTId, checksum) ⇒ Basket
 *Add item to the basket*
 **Returns**: Basket - *basket*  
 
@@ -200,8 +199,8 @@ interface Amount {
 |-------------|-----------------------------|
 | basket      | Basket                      | 
 | basketItems | Array&lt;BasketItemData&gt; | 
-| checksum    | string                      |
 | returnTTId  | bool                        | 
+| checksum    | string                      |
 
 ```typescript
 interface BasketItemData {
@@ -248,7 +247,7 @@ interface Amount {
 }
 ```
 
-#### ➥ replaceItems(basket, basketItems, checksum, returnTTId) ⇒ Basket
+#### ➥ replaceItems(basket, basketItems, returnTTId) ⇒ Basket
 *Replace items in basket with new items*
 **Returns**: Basket - *basket*  
 
@@ -256,7 +255,6 @@ interface Amount {
 |-------------|-----------------------------|
 | basket      | Basket                      | 
 | basketItems | Array&lt;BasketItemData&gt; | 
-| checksum    | string                      |
 | returnTTId  | bool                        | 
 
 ```typescript
@@ -314,7 +312,7 @@ interface Amount {
 | itemId | number | 
 | [channelId] | string | 
 
-#### ➥ addPromoCode(basket, promoCode, checksum, returnTTId) ⇒ Basket
+#### ➥ addPromoCode(basket, promoCode, returnTTId, checksum) ⇒ Basket
 *Apply promo code*
 **Returns**: Basket - *basket*  
 
@@ -322,18 +320,18 @@ interface Amount {
 |------------|--------|
 | basket     | Basket | 
 | promoCode  | string | 
-| checksum   | string |
 | returnTTId | bool   | 
+| checksum   | string |
 
-#### ➥ removePromoCode(basket, checksum, returnTTId) ⇒ Basket
+#### ➥ removePromoCode(basket, returnTTId, checksum) ⇒ Basket
 *Remove promo code*
 **Returns**: Basket - *basket*  
 
 | Param      | Type   |
 |------------|--------|
 | basket     | Basket |
-| checksum   | string |
 | returnTTId | bool   |
+| checksum   | string |
 
 #### ➥ clearBasket(basketReference, [channelId]) ⇒ Basket
 *Remove all items from basket*

--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ interface SourceInformation {
 }
 ```
 
-* getBasket(reference, checksum, [channelId], returnTTId) ⇒ Basket
-* createBasket(basketData, checksum, returnTTId) ⇒ Basket
-* getDeliveries(basketReference, basketItems, checksum, [channelId]) ⇒ Array&lt;Delivery&gt;
+* getBasket(reference, [channelId], returnTTId, checksum) ⇒ Basket
+* createBasket(basketData, returnTTId) ⇒ Basket
+* getDeliveries(basketReference, basketItems, [channelId], checksum) ⇒ Array&lt;Delivery&gt;
 * setSelectedDelivery(basket, selectedDelivery, checksum) ⇒ Basket
-* addItems(basket, basketItems, checksum, returnTTId) ⇒ Basket
-* replaceItems(basket, basketItems, checksum, returnTTId) ⇒ Basket
+* addItems(basket, basketItems, returnTTId, checksum) ⇒ Basket
+* replaceItems(basket, basketItems, returnTTId) ⇒ Basket
 * removeItem(basketReference, itemId, [channelId]) ⇒ Basket
-* addPromoCode(basket, promoCode, checksum, returnTTId) ⇒ Basket
-* removePromoCode(basket, checksum, returnTTId) ⇒ Basket
+* addPromoCode(basket, promoCode, returnTTId, checksum) ⇒ Basket
+* removePromoCode(basket, returnTTId, checksum) ⇒ Basket
 * clearBasket(basketReference, [channelId]) ⇒ Basket
 
 #### ➥ getBasket(reference, checksum, [channelId], returnTTId) ⇒ Basket

--- a/README.md
+++ b/README.md
@@ -56,34 +56,36 @@ interface SourceInformation {
 }
 ```
 
-* getBasket(reference, [channelId], returnTTId) ⇒ Basket
-* createBasket(basketData, returnTTId) ⇒ Basket
-* getDeliveries(basketReference, basketItems, [channelId]) ⇒ Array&lt;Delivery&gt;
-* setSelectedDelivery(basket, selectedDelivery) ⇒ Basket
-* addItems(basket, basketItems, returnTTId) ⇒ Basket
-* replaceItems(basket, basketItems, returnTTId) ⇒ Basket
+* getBasket(reference, checksum, [channelId], returnTTId) ⇒ Basket
+* createBasket(basketData, checksum, returnTTId) ⇒ Basket
+* getDeliveries(basketReference, basketItems, checksum, [channelId]) ⇒ Array&lt;Delivery&gt;
+* setSelectedDelivery(basket, selectedDelivery, checksum) ⇒ Basket
+* addItems(basket, basketItems, checksum, returnTTId) ⇒ Basket
+* replaceItems(basket, basketItems, checksum, returnTTId) ⇒ Basket
 * removeItem(basketReference, itemId, [channelId]) ⇒ Basket
-* addPromoCode(basket, promoCode, returnTTId) ⇒ Basket
-* removePromoCode(basket, returnTTId) ⇒ Basket
+* addPromoCode(basket, promoCode, checksum, returnTTId) ⇒ Basket
+* removePromoCode(basket, checksum, returnTTId) ⇒ Basket
 * clearBasket(basketReference, [channelId]) ⇒ Basket
 
-#### ➥ getBasket(reference, [channelId], returnTTId) ⇒ Basket
+#### ➥ getBasket(reference, checksum, [channelId], returnTTId) ⇒ Basket
 *Get basket by reference*
 **Returns**: Basket - *basket model*  
 
 | Param       | Type   |
 |-------------|--------|
 | reference   | string | 
+| checksum    | string |
 | [channelId] | string | 
 | returnTTId  | bool   | 
 
-#### ➥ createBasket(basketData, returnTTId) ⇒ Basket
+#### ➥ createBasket(basketData, checksum, returnTTId) ⇒ Basket
 *Create new basket*
 **Returns**: Basket - *basket model*  
 
 | Param      | Type              |
 |------------|-------------------|
 | basketData | RequestBasketData | 
+| checksum   | string            |
 | returnTTId | bool              | 
 
 ```typescript
@@ -144,7 +146,7 @@ enum ProductType {
 }
 ```
 
-#### ➥ getDeliveries(basketReference, basketItems, [channelId]) ⇒ Array&lt;Delivery&gt;
+#### ➥ getDeliveries(basketReference, basketItems, checksum, [channelId]) ⇒ Array&lt;Delivery&gt;
 *Get delivery options available for basket*
 **Returns**: Array&lt;Delivery&gt; - *delivery models*  
 
@@ -152,9 +154,10 @@ enum ProductType {
 | --- | --- |
 | basketReference | string | 
 | basketItems | BasketItemsCollection | 
+| checksum    | string |
 | [channelId] | string | 
 
-#### ➥ setSelectedDelivery(basket, selectedDelivery) ⇒ Basket
+#### ➥ setSelectedDelivery(basket, selectedDelivery, checksum) ⇒ Basket
 *Set delivery option*
 **Returns**: Basket - *basket*  
 
@@ -162,6 +165,7 @@ enum ProductType {
 | --- | --- |
 | basket | Basket | 
 | selectedDelivery | DeliveryData | 
+| checksum         | string       |
 
 ```typescript
 interface DeliveryData {
@@ -188,7 +192,7 @@ interface Amount {
 }
 ```
 
-#### ➥ addItems(basket, basketItems, returnTTId) ⇒ Basket
+#### ➥ addItems(basket, basketItems, checksum, returnTTId) ⇒ Basket
 *Add item to the basket*
 **Returns**: Basket - *basket*  
 
@@ -196,6 +200,7 @@ interface Amount {
 |-------------|-----------------------------|
 | basket      | Basket                      | 
 | basketItems | Array&lt;BasketItemData&gt; | 
+| checksum    | string                      |
 | returnTTId  | bool                        | 
 
 ```typescript
@@ -243,7 +248,7 @@ interface Amount {
 }
 ```
 
-#### ➥ replaceItems(basket, basketItems, returnTTId) ⇒ Basket
+#### ➥ replaceItems(basket, basketItems, checksum, returnTTId) ⇒ Basket
 *Replace items in basket with new items*
 **Returns**: Basket - *basket*  
 
@@ -251,6 +256,7 @@ interface Amount {
 |-------------|-----------------------------|
 | basket      | Basket                      | 
 | basketItems | Array&lt;BasketItemData&gt; | 
+| checksum    | string                      |
 | returnTTId  | bool                        | 
 
 ```typescript
@@ -308,7 +314,7 @@ interface Amount {
 | itemId | number | 
 | [channelId] | string | 
 
-#### ➥ addPromoCode(basket, promoCode, returnTTId) ⇒ Basket
+#### ➥ addPromoCode(basket, promoCode, checksum, returnTTId) ⇒ Basket
 *Apply promo code*
 **Returns**: Basket - *basket*  
 
@@ -316,15 +322,17 @@ interface Amount {
 |------------|--------|
 | basket     | Basket | 
 | promoCode  | string | 
+| checksum   | string |
 | returnTTId | bool   | 
 
-#### ➥ removePromoCode(basket, returnTTId) ⇒ Basket
+#### ➥ removePromoCode(basket, checksum, returnTTId) ⇒ Basket
 *Remove promo code*
 **Returns**: Basket - *basket*  
 
 | Param      | Type   |
 |------------|--------|
 | basket     | Basket |
+| checksum   | string |
 | returnTTId | bool   |
 
 #### ➥ clearBasket(basketReference, [channelId]) ⇒ Basket

--- a/src/basket-service/services/__tests__/api-provider.spec.ts
+++ b/src/basket-service/services/__tests__/api-provider.spec.ts
@@ -58,7 +58,19 @@ describe('Basket API', () => {
   describe('getBasket function', () => {
     it('should get basket', async () => {
       const reference = 'test';
-      await basketApi.getBasket(reference, testChecksum, null, false);
+      await basketApi.getBasket(reference);
+
+      expect(httpClient.get).toBeCalledWith(
+        `/baskets/${reference}?returnTTId=false`,
+        {
+          headers: additionalHeaders,
+        },
+      );
+    });
+
+    it('should get basket with password', async () => {
+      const reference = 'test';
+      await basketApi.getBasket(reference, null, false, testChecksum);
 
       expect(httpClient.get).toBeCalledWith(
         `/baskets/${reference}?returnTTId=false`,
@@ -70,12 +82,12 @@ describe('Basket API', () => {
 
     it('should get basket with affiliateId header', async () => {
       const reference = 'test';
-      await basketApi.getBasket(reference, testChecksum, testChannelId);
+      await basketApi.getBasket(reference, testChannelId, false, testChecksum);
 
       expect(httpClient.get).toBeCalledWith(
         `/baskets/${reference}?returnTTId=false`,
         {
-          headers: headersWithPassword,
+          headers: { ...headersWithAffiliate, 'x-ttg-password': testChecksum },
         },
       );
     });
@@ -84,24 +96,24 @@ describe('Basket API', () => {
   describe('getDeliveries function', () => {
     it('should get deliveriesMock', async () => {
       const reference = 'test';
-      await basketApi.getDeliveries(reference, testChecksum);
+      await basketApi.getDeliveries(reference);
 
       expect(httpClient.get).toBeCalledWith(
         `/baskets/${reference}/deliveryOptions`,
         {
-          headers: headersWithPassword,
+          headers: additionalHeaders,
         },
       );
     });
 
     it('should get deliveriesMock with affiliateId header', async () => {
       const reference = 'test';
-      await basketApi.getDeliveries(reference, testChecksum, testChannelId);
+      await basketApi.getDeliveries(reference, testChannelId, testChecksum);
 
       expect(httpClient.get).toBeCalledWith(
         `/baskets/${reference}/deliveryOptions`,
         {
-          headers: headersWithPassword,
+          headers: { ...headersWithAffiliate, 'x-ttg-password': testChecksum },
         },
       );
     });
@@ -111,21 +123,21 @@ describe('Basket API', () => {
     it('should apply delivery', async () => {
       const reference = 'test';
       const delivery = deliveriesMock[0];
-      await basketApi.applyDelivery(reference, delivery, testChecksum);
+      await basketApi.applyDelivery(reference, delivery);
 
       expect(httpClient.patch).toBeCalledWith(
         `/baskets/${reference}/applyDelivery`,
         { delivery },
         {
-          headers: headersWithPassword,
+          headers: additionalHeaders,
         },
       );
     });
 
-    it('should apply delivery with affiliateId header', async () => {
+    it('should apply delivery with password and affiliateId header', async () => {
       const reference = 'test';
       const delivery = deliveriesMock[0];
-      await basketApi.applyDelivery(reference, delivery, testChecksum, testChannelId);
+      await basketApi.applyDelivery(reference, delivery, testChannelId, testChecksum);
 
       expect(httpClient.patch).toBeCalledWith(
         `/baskets/${reference}/applyDelivery`,
@@ -148,7 +160,7 @@ describe('Basket API', () => {
         shopperCurrency,
       } = basketDataMock;
 
-      await basketApi.upsertBasket(basketDataMock, testChecksum, false);
+      await basketApi.upsertBasket(basketDataMock, false, undefined, testChecksum);
 
       expect(httpClient.patch).toBeCalledWith(
         '/baskets?returnTTId=false',
@@ -169,7 +181,7 @@ describe('Basket API', () => {
     it('should return basket API response if data not set', async () => {
       (httpClient.patch as jest.Mock).mockImplementationOnce(() => Promise.resolve([{}]));
 
-      const result = await basketApi.upsertBasket(basketDataMock, undefined);
+      const result = await basketApi.upsertBasket(basketDataMock);
 
       expect(result).toEqual({});
     });

--- a/src/basket-service/services/__tests__/api-provider.spec.ts
+++ b/src/basket-service/services/__tests__/api-provider.spec.ts
@@ -26,6 +26,7 @@ describe('Basket API', () => {
   };
   const basketApi = getBasketServiceApi(Environment.Dev, null, sourceInformation);
   const testChannelId = 'test-qa-encoretickets';
+  const testChecksum = 'test-12345-abc';
   const additionalHeaders = {
     'x-ttg-client': 'Source name | View name using JS SDK',
     'x-ttg-client-version': 'Source version',
@@ -33,7 +34,11 @@ describe('Basket API', () => {
   const headersWithAffiliate = {
     ...{ affiliateId: 'encoretickets' },
     ...additionalHeaders,
-  }
+  };
+  const headersWithPassword = {
+    ...{ 'x-ttg-password': testChecksum },
+    ...additionalHeaders,
+  };
 
   beforeEach(() => {
     httpClient = getMockFunctionReturnValue(getHttpClient);
@@ -53,24 +58,24 @@ describe('Basket API', () => {
   describe('getBasket function', () => {
     it('should get basket', async () => {
       const reference = 'test';
-      await basketApi.getBasket(reference, null, false);
+      await basketApi.getBasket(reference, testChecksum, null, false);
 
       expect(httpClient.get).toBeCalledWith(
         `/baskets/${reference}?returnTTId=false`,
         {
-          headers: additionalHeaders,
+          headers: headersWithPassword,
         },
       );
     });
 
     it('should get basket with affiliateId header', async () => {
       const reference = 'test';
-      await basketApi.getBasket(reference, testChannelId);
+      await basketApi.getBasket(reference, testChecksum, testChannelId);
 
       expect(httpClient.get).toBeCalledWith(
         `/baskets/${reference}?returnTTId=false`,
         {
-          headers: headersWithAffiliate,
+          headers: headersWithPassword,
         },
       );
     });
@@ -79,24 +84,24 @@ describe('Basket API', () => {
   describe('getDeliveries function', () => {
     it('should get deliveriesMock', async () => {
       const reference = 'test';
-      await basketApi.getDeliveries(reference);
+      await basketApi.getDeliveries(reference, testChecksum);
 
       expect(httpClient.get).toBeCalledWith(
         `/baskets/${reference}/deliveryOptions`,
         {
-          headers: additionalHeaders,
+          headers: headersWithPassword,
         },
       );
     });
 
     it('should get deliveriesMock with affiliateId header', async () => {
       const reference = 'test';
-      await basketApi.getDeliveries(reference, testChannelId);
+      await basketApi.getDeliveries(reference, testChecksum, testChannelId);
 
       expect(httpClient.get).toBeCalledWith(
         `/baskets/${reference}/deliveryOptions`,
         {
-          headers: headersWithAffiliate,
+          headers: headersWithPassword,
         },
       );
     });
@@ -106,13 +111,13 @@ describe('Basket API', () => {
     it('should apply delivery', async () => {
       const reference = 'test';
       const delivery = deliveriesMock[0];
-      await basketApi.applyDelivery(reference, delivery);
+      await basketApi.applyDelivery(reference, delivery, testChecksum);
 
       expect(httpClient.patch).toBeCalledWith(
         `/baskets/${reference}/applyDelivery`,
         { delivery },
         {
-          headers: additionalHeaders,
+          headers: headersWithPassword,
         },
       );
     });
@@ -120,13 +125,13 @@ describe('Basket API', () => {
     it('should apply delivery with affiliateId header', async () => {
       const reference = 'test';
       const delivery = deliveriesMock[0];
-      await basketApi.applyDelivery(reference, delivery, testChannelId);
+      await basketApi.applyDelivery(reference, delivery, testChecksum, testChannelId);
 
       expect(httpClient.patch).toBeCalledWith(
         `/baskets/${reference}/applyDelivery`,
         { delivery },
         {
-          headers: headersWithAffiliate,
+          headers: { ...headersWithAffiliate, 'x-ttg-password': testChecksum },
         },
       );
     });
@@ -143,7 +148,7 @@ describe('Basket API', () => {
         shopperCurrency,
       } = basketDataMock;
 
-      await basketApi.upsertBasket(basketDataMock, false);
+      await basketApi.upsertBasket(basketDataMock, testChecksum, false);
 
       expect(httpClient.patch).toBeCalledWith(
         '/baskets?returnTTId=false',
@@ -156,7 +161,7 @@ describe('Basket API', () => {
           shopperCurrency,
         },
         {
-          headers: headersWithAffiliate,
+          headers: { ...headersWithAffiliate, 'x-ttg-password': testChecksum },
         },
       );
     });
@@ -164,7 +169,7 @@ describe('Basket API', () => {
     it('should return basket API response if data not set', async () => {
       (httpClient.patch as jest.Mock).mockImplementationOnce(() => Promise.resolve([{}]));
 
-      const result = await basketApi.upsertBasket(basketDataMock);
+      const result = await basketApi.upsertBasket(basketDataMock, undefined);
 
       expect(result).toEqual({});
     });

--- a/src/basket-service/services/__tests__/repository-provider.spec.ts
+++ b/src/basket-service/services/__tests__/repository-provider.spec.ts
@@ -80,18 +80,20 @@ describe('Basket repository', () => {
 
   it('should return basket', async () => {
     const reference = 'test';
-    await getBasket(reference);
+    const checksum = 'checksum';
+    await getBasket(reference, checksum);
 
-    expect(getBasketData).toBeCalledWith(reference, undefined, false);
+    expect(getBasketData).toBeCalledWith(reference, checksum, undefined, false);
     expect(Basket).toBeCalledWith(basketDataMock);
   });
 
   it('should return basket with channel id', async () => {
     const reference = 'test';
     const channelId = 'channel';
-    await getBasket(reference, channelId, true);
+    const checksum = 'checksum';
+    await getBasket(reference, checksum, channelId, true);
 
-    expect(getBasketData).toBeCalledWith(reference, channelId, true);
+    expect(getBasketData).toBeCalledWith(reference, checksum, channelId, true);
     expect(Basket).toBeCalledWith(basketDataMock);
   });
 
@@ -101,12 +103,13 @@ describe('Basket repository', () => {
     const basket = new Basket(basketDataMock);
     const reference = basket.getReference();
     const basketCollection = basket.getItemsCollection();
+    const checksum = 'checksum';
 
-    await getDeliveries(reference, basketCollection);
+    await getDeliveries(reference, basketCollection, checksum);
 
     const [ deliveryData, itemsToDeliver ] = getMockFunctionArguments(Delivery);
 
-    expect(getDeliveriesData).toBeCalledWith(reference, undefined);
+    expect(getDeliveriesData).toBeCalledWith(reference, checksum, undefined);
     expect(Delivery).toBeCalledTimes(2);
     expect(deliveryData).toEqual(deliveriesMock[0]);
     expect(itemsToDeliver).toEqual(basketCollection);
@@ -119,12 +122,13 @@ describe('Basket repository', () => {
     const reference = basket.getReference();
     const channelId = 'channel';
     const basketCollection = basket.getItemsCollection();
+    const checksum = 'checksum';
 
-    await getDeliveries(reference, basketCollection, channelId);
+    await getDeliveries(reference, basketCollection, checksum, channelId);
 
     const [ deliveryData, itemsToDeliver ] = getMockFunctionArguments(Delivery);
 
-    expect(getDeliveriesData).toBeCalledWith(reference, channelId);
+    expect(getDeliveriesData).toBeCalledWith(reference, checksum, channelId);
     expect(Delivery).toBeCalledTimes(2);
     expect(deliveryData).toEqual(deliveriesMock[0]);
     expect(itemsToDeliver).toEqual(basketCollection);
@@ -132,17 +136,17 @@ describe('Basket repository', () => {
 
   it('should create basket', async () => {
     jest.mock('../../models/basket');
-    await createBasket(basketDataMock);
+    await createBasket(basketDataMock, 'checksum');
 
-    expect(upsertBasketData).toBeCalledWith(basketDataMock, false, undefined);
+    expect(upsertBasketData).toBeCalledWith(basketDataMock, 'checksum', false, undefined);
     expect(Basket).toBeCalledWith(basketDataMock);
   });
 
   it('should create basket and returnTTId', async () => {
     jest.mock('../../models/basket');
-    await createBasket(basketDataMock, true, 'faketoken');
+    await createBasket(basketDataMock,'checksum', true, 'faketoken');
 
-    expect(upsertBasketData).toBeCalledWith(basketDataMock, true, 'faketoken');
+    expect(upsertBasketData).toBeCalledWith(basketDataMock, 'checksum', true, 'faketoken');
     expect(Basket).toBeCalledWith(basketDataMock);
   });
 
@@ -150,10 +154,10 @@ describe('Basket repository', () => {
     mockBasket();
 
     const basket = new Basket(basketDataMock);
-    await addItems(basket, [basketItemDataMock, basketItemDataMock]);
+    await addItems(basket, [basketItemDataMock, basketItemDataMock], 'checksum');
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
-    expect(callArguments.length).toBe(2);
+    expect(callArguments.length).toBe(3);
     expect((callArguments[0] as BasketData).reservations.length).toBe(4);
   });
 
@@ -194,10 +198,10 @@ describe('Basket repository', () => {
     mockBasket();
 
     const basket = new Basket(basketDataMock);
-    await replaceItems(basket, [basketItemDataMock]);
+    await replaceItems(basket, [basketItemDataMock], 'checksum');
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
-    expect(callArguments.length).toBe(3);
+    expect(callArguments.length).toBe(4);
     expect((callArguments[0] as BasketData).reservations.length).toBe(2);
   });
 
@@ -205,10 +209,10 @@ describe('Basket repository', () => {
     mockBasket();
 
     const basket = new Basket(basketDataMock);
-    await replaceItems(basket, [basketItemDataMock], true);
+    await replaceItems(basket, [basketItemDataMock], 'checksum', true);
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
-    expect(callArguments.length).toBe(3);
+    expect(callArguments.length).toBe(4);
     expect((callArguments[0] as BasketData).reservations.length).toBe(2);
   });
 
@@ -228,7 +232,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().delivery).toEqual(basketDataMock.delivery);
 
-    await setSelectedDelivery(basket, deliveryData);
+    await setSelectedDelivery(basket, deliveryData, 'checksum');
 
     expect(basket.getBasketData().delivery).toEqual(deliveryData);
   });
@@ -241,7 +245,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().coupon).toBe(basketDataMock.coupon);
 
-    await addPromoCode(basket, promoCode);
+    await addPromoCode(basket, promoCode, 'checksum');
 
     expect(basket.getBasketData().coupon).toEqual({ code: promoCode });
   });
@@ -253,7 +257,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().coupon).toBe(basketDataMock.coupon);
 
-    await removePromoCode(basket);
+    await removePromoCode(basket, 'checksum');
 
     expect(basket.getBasketData().coupon).toBeNull();
   });
@@ -266,7 +270,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().coupon).toBe(basketDataMock.coupon);
 
-    await addPromoCode(basket, promoCode, true);
+    await addPromoCode(basket, promoCode, 'checksum', true);
 
     expect(basket.getBasketData().coupon).toEqual({ code: promoCode });
   });
@@ -278,7 +282,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().coupon).toBe(basketDataMock.coupon);
 
-    await removePromoCode(basket, true);
+    await removePromoCode(basket, 'checksum', true);
 
     expect(basket.getBasketData().coupon).toBeNull();
   });
@@ -294,12 +298,12 @@ describe('Basket repository', () => {
     };
     const basket = new Basket(basketDataMock);
 
-    await setUpsellProducts(basket, upsellProducts);
+    await setUpsellProducts(basket, upsellProducts, 'checksum');
 
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
     expect(basket.prepareBasketData).toBeCalledWith(upsellProducts);
-    expect(callArguments.length).toBe(2);
+    expect(callArguments.length).toBe(3);
   });
 
   it('should set upsell products and return TT Id', async () => {
@@ -313,12 +317,12 @@ describe('Basket repository', () => {
     };
     const basket = new Basket(basketDataMock);
 
-    await setUpsellProducts(basket, upsellProducts, true);
+    await setUpsellProducts(basket, upsellProducts, 'checksum', true);
 
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
     expect(basket.prepareBasketData).toBeCalledWith(upsellProducts);
-    expect(callArguments.length).toBe(2);
+    expect(callArguments.length).toBe(3);
   });
 
   describe('upsertBasket function', () => {
@@ -326,10 +330,10 @@ describe('Basket repository', () => {
       mockBasket();
 
       const basket = new Basket(basketDataMock);
-      await upsertBasket(basket);
+      await upsertBasket(basket, 'checksum');
       const callArguments = getMockFunctionArguments(upsertBasketData);
 
-      expect(callArguments.length).toBe(2);
+      expect(callArguments.length).toBe(3);
       expect((callArguments[0] as BasketData).reservations.length).toBe(2);
     })
   });
@@ -339,10 +343,10 @@ describe('Basket repository', () => {
       mockBasket();
 
       const basket = new Basket(basketDataMock);
-      await upsertBasket(basket, null, true);
+      await upsertBasket(basket, 'checksum', null, true);
       const callArguments = getMockFunctionArguments(upsertBasketData);
 
-      expect(callArguments.length).toBe(2);
+      expect(callArguments.length).toBe(3);
       expect((callArguments[0] as BasketData).reservations.length).toBe(2);
     })
   });
@@ -377,10 +381,10 @@ describe('Basket repository', () => {
       mockBasket();
 
       const basket = new Basket(basketDataMock);
-      await addItems(basket, [basketItemDataMock, basketItemDataMock], true);
+      await addItems(basket, [basketItemDataMock, basketItemDataMock], 'checksum', true);
       const callArguments = getMockFunctionArguments(upsertBasketData);
 
-      expect(callArguments.length).toBe(2);
+      expect(callArguments.length).toBe(3);
       expect((callArguments[0] as BasketData).reservations.length).toBe(4);
     });
   });

--- a/src/basket-service/services/__tests__/repository-provider.spec.ts
+++ b/src/basket-service/services/__tests__/repository-provider.spec.ts
@@ -80,20 +80,19 @@ describe('Basket repository', () => {
 
   it('should return basket', async () => {
     const reference = 'test';
-    const checksum = 'checksum';
-    await getBasket(reference, checksum);
+    await getBasket(reference);
 
-    expect(getBasketData).toBeCalledWith(reference, checksum, undefined, false);
+    expect(getBasketData).toBeCalledWith(reference, undefined, false, undefined);
     expect(Basket).toBeCalledWith(basketDataMock);
   });
 
-  it('should return basket with channel id', async () => {
+  it('should return basket with channel id and password', async () => {
     const reference = 'test';
     const channelId = 'channel';
     const checksum = 'checksum';
-    await getBasket(reference, checksum, channelId, true);
+    await getBasket(reference, channelId, true, checksum);
 
-    expect(getBasketData).toBeCalledWith(reference, checksum, channelId, true);
+    expect(getBasketData).toBeCalledWith(reference, channelId, true, checksum);
     expect(Basket).toBeCalledWith(basketDataMock);
   });
 
@@ -103,19 +102,18 @@ describe('Basket repository', () => {
     const basket = new Basket(basketDataMock);
     const reference = basket.getReference();
     const basketCollection = basket.getItemsCollection();
-    const checksum = 'checksum';
 
-    await getDeliveries(reference, basketCollection, checksum);
+    await getDeliveries(reference, basketCollection);
 
     const [ deliveryData, itemsToDeliver ] = getMockFunctionArguments(Delivery);
 
-    expect(getDeliveriesData).toBeCalledWith(reference, checksum, undefined);
+    expect(getDeliveriesData).toBeCalledWith(reference, undefined, undefined);
     expect(Delivery).toBeCalledTimes(2);
     expect(deliveryData).toEqual(deliveriesMock[0]);
     expect(itemsToDeliver).toEqual(basketCollection);
   });
 
-  it('should return deliveriesMock', async () => {
+  it('should return deliveriesMock with channel id and password', async () => {
     mockBasket();
 
     const basket = new Basket(basketDataMock);
@@ -124,11 +122,11 @@ describe('Basket repository', () => {
     const basketCollection = basket.getItemsCollection();
     const checksum = 'checksum';
 
-    await getDeliveries(reference, basketCollection, checksum, channelId);
+    await getDeliveries(reference, basketCollection, channelId, checksum);
 
     const [ deliveryData, itemsToDeliver ] = getMockFunctionArguments(Delivery);
 
-    expect(getDeliveriesData).toBeCalledWith(reference, checksum, channelId);
+    expect(getDeliveriesData).toBeCalledWith(reference, channelId, checksum);
     expect(Delivery).toBeCalledTimes(2);
     expect(deliveryData).toEqual(deliveriesMock[0]);
     expect(itemsToDeliver).toEqual(basketCollection);
@@ -136,17 +134,17 @@ describe('Basket repository', () => {
 
   it('should create basket', async () => {
     jest.mock('../../models/basket');
-    await createBasket(basketDataMock, 'checksum');
+    await createBasket(basketDataMock);
 
-    expect(upsertBasketData).toBeCalledWith(basketDataMock, 'checksum', false, undefined);
+    expect(upsertBasketData).toBeCalledWith(basketDataMock, false, undefined);
     expect(Basket).toBeCalledWith(basketDataMock);
   });
 
   it('should create basket and returnTTId', async () => {
     jest.mock('../../models/basket');
-    await createBasket(basketDataMock,'checksum', true, 'faketoken');
+    await createBasket(basketDataMock, true, 'faketoken');
 
-    expect(upsertBasketData).toBeCalledWith(basketDataMock, 'checksum', true, 'faketoken');
+    expect(upsertBasketData).toBeCalledWith(basketDataMock, true, 'faketoken');
     expect(Basket).toBeCalledWith(basketDataMock);
   });
 
@@ -154,10 +152,10 @@ describe('Basket repository', () => {
     mockBasket();
 
     const basket = new Basket(basketDataMock);
-    await addItems(basket, [basketItemDataMock, basketItemDataMock], 'checksum');
+    await addItems(basket, [basketItemDataMock, basketItemDataMock]);
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
-    expect(callArguments.length).toBe(3);
+    expect(callArguments.length).toBe(4);
     expect((callArguments[0] as BasketData).reservations.length).toBe(4);
   });
 
@@ -198,10 +196,10 @@ describe('Basket repository', () => {
     mockBasket();
 
     const basket = new Basket(basketDataMock);
-    await replaceItems(basket, [basketItemDataMock], 'checksum');
+    await replaceItems(basket, [basketItemDataMock]);
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
-    expect(callArguments.length).toBe(4);
+    expect(callArguments.length).toBe(3);
     expect((callArguments[0] as BasketData).reservations.length).toBe(2);
   });
 
@@ -209,10 +207,10 @@ describe('Basket repository', () => {
     mockBasket();
 
     const basket = new Basket(basketDataMock);
-    await replaceItems(basket, [basketItemDataMock], 'checksum', true);
+    await replaceItems(basket, [basketItemDataMock], true);
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
-    expect(callArguments.length).toBe(4);
+    expect(callArguments.length).toBe(3);
     expect((callArguments[0] as BasketData).reservations.length).toBe(2);
   });
 
@@ -245,7 +243,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().coupon).toBe(basketDataMock.coupon);
 
-    await addPromoCode(basket, promoCode, 'checksum');
+    await addPromoCode(basket, promoCode);
 
     expect(basket.getBasketData().coupon).toEqual({ code: promoCode });
   });
@@ -257,7 +255,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().coupon).toBe(basketDataMock.coupon);
 
-    await removePromoCode(basket, 'checksum');
+    await removePromoCode(basket);
 
     expect(basket.getBasketData().coupon).toBeNull();
   });
@@ -270,7 +268,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().coupon).toBe(basketDataMock.coupon);
 
-    await addPromoCode(basket, promoCode, 'checksum', true);
+    await addPromoCode(basket, promoCode, true, 'checksum');
 
     expect(basket.getBasketData().coupon).toEqual({ code: promoCode });
   });
@@ -282,7 +280,7 @@ describe('Basket repository', () => {
 
     expect(basket.getBasketData().coupon).toBe(basketDataMock.coupon);
 
-    await removePromoCode(basket, 'checksum', true);
+    await removePromoCode(basket, true, 'checksum');
 
     expect(basket.getBasketData().coupon).toBeNull();
   });
@@ -298,12 +296,12 @@ describe('Basket repository', () => {
     };
     const basket = new Basket(basketDataMock);
 
-    await setUpsellProducts(basket, upsellProducts, 'checksum');
+    await setUpsellProducts(basket, upsellProducts);
 
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
     expect(basket.prepareBasketData).toBeCalledWith(upsellProducts);
-    expect(callArguments.length).toBe(3);
+    expect(callArguments.length).toBe(4);
   });
 
   it('should set upsell products and return TT Id', async () => {
@@ -317,12 +315,12 @@ describe('Basket repository', () => {
     };
     const basket = new Basket(basketDataMock);
 
-    await setUpsellProducts(basket, upsellProducts, 'checksum', true);
+    await setUpsellProducts(basket, upsellProducts, true, 'checksum');
 
     const callArguments = getMockFunctionArguments(upsertBasketData);
 
     expect(basket.prepareBasketData).toBeCalledWith(upsellProducts);
-    expect(callArguments.length).toBe(3);
+    expect(callArguments.length).toBe(4);
   });
 
   describe('upsertBasket function', () => {
@@ -330,10 +328,10 @@ describe('Basket repository', () => {
       mockBasket();
 
       const basket = new Basket(basketDataMock);
-      await upsertBasket(basket, 'checksum');
+      await upsertBasket(basket);
       const callArguments = getMockFunctionArguments(upsertBasketData);
 
-      expect(callArguments.length).toBe(3);
+      expect(callArguments.length).toBe(4);
       expect((callArguments[0] as BasketData).reservations.length).toBe(2);
     })
   });
@@ -343,10 +341,10 @@ describe('Basket repository', () => {
       mockBasket();
 
       const basket = new Basket(basketDataMock);
-      await upsertBasket(basket, 'checksum', null, true);
+      await upsertBasket(basket, null, true, 'checksum');
       const callArguments = getMockFunctionArguments(upsertBasketData);
 
-      expect(callArguments.length).toBe(3);
+      expect(callArguments.length).toBe(4);
       expect((callArguments[0] as BasketData).reservations.length).toBe(2);
     })
   });
@@ -381,10 +379,10 @@ describe('Basket repository', () => {
       mockBasket();
 
       const basket = new Basket(basketDataMock);
-      await addItems(basket, [basketItemDataMock, basketItemDataMock], 'checksum', true);
+      await addItems(basket, [basketItemDataMock, basketItemDataMock], true, 'checksum');
       const callArguments = getMockFunctionArguments(upsertBasketData);
 
-      expect(callArguments.length).toBe(3);
+      expect(callArguments.length).toBe(4);
       expect((callArguments[0] as BasketData).reservations.length).toBe(4);
     });
   });

--- a/src/basket-service/services/api-provider.ts
+++ b/src/basket-service/services/api-provider.ts
@@ -20,7 +20,7 @@ export const getBasketServiceApi = (
   const reservationsPath = '/reservations';
   const additionalHeaders = getAdditionalHeaders(sourceInformation, true);
 
-  const upsertBasket = async (basketData: RequestBasketData, checksum: string, returnTTId: boolean = false, jwt?: string): Promise<BasketData | ApiError> => {
+  const upsertBasket = async (basketData: RequestBasketData, returnTTId: boolean = false, jwt?: string, checksum?: string): Promise<BasketData | ApiError> => {
     checkRequiredProperty(basketData, 'upsertBasket: basket data');
 
     const {
@@ -76,7 +76,7 @@ export const getBasketServiceApi = (
     return data;
   };
 
-  const getBasket = async (reference: string, checksum: string, channelId?: string, returnTTId: boolean = false): Promise<BasketData> => {
+  const getBasket = async (reference: string, channelId?: string, returnTTId: boolean = false, checksum?: string): Promise<BasketData> => {
     checkRequiredProperty(reference, 'getBasket: basket reference');
 
     const requestUrl = `${basketsPath}/${reference}?returnTTId=${returnTTId}`;
@@ -94,7 +94,7 @@ export const getBasketServiceApi = (
     return data;
   };
 
-  const getDeliveries = async (reference: string, checksum: string, channelId?: string): Promise<DeliveryData[]> => {
+  const getDeliveries = async (reference: string, channelId?: string, checksum?: string): Promise<DeliveryData[]> => {
     checkRequiredProperty(reference, 'getDeliveries: basket reference');
 
     const requestUrl = `${basketsPath}/${reference}${deliveriesPath}`;
@@ -115,8 +115,8 @@ export const getBasketServiceApi = (
   const applyDelivery = async (
     reference: string,
     delivery: DeliveryData,
-    checksum: string,
-    channelId?: string
+    channelId?: string,
+    checksum?: string,
   ): Promise<BasketData> => {
     checkRequiredProperty(reference, 'applyDelivery: basket reference');
     checkRequiredProperty(delivery, 'applyDelivery: delivery data');

--- a/src/basket-service/services/api-provider.ts
+++ b/src/basket-service/services/api-provider.ts
@@ -1,5 +1,5 @@
 import { getHttpClient } from '../../http-client-provider';
-import { checkRequiredProperty, getAdditionalHeaders, getAuthHeader } from '../../utils';
+import { checkRequiredProperty, getAdditionalHeaders, getAuthHeader, getPasswordHeader } from '../../utils';
 import { pathSettings } from '../constants/path-settings';
 import { BasketData, DeliveryData, RequestBasketData } from '../typings';
 import { ApiError, Environment, SourceInformation } from '../../shared/typings';
@@ -20,7 +20,7 @@ export const getBasketServiceApi = (
   const reservationsPath = '/reservations';
   const additionalHeaders = getAdditionalHeaders(sourceInformation, true);
 
-  const upsertBasket = async (basketData: RequestBasketData, returnTTId: boolean = false, jwt?: string): Promise<BasketData | ApiError> => {
+  const upsertBasket = async (basketData: RequestBasketData, checksum: string, returnTTId: boolean = false, jwt?: string): Promise<BasketData | ApiError> => {
     checkRequiredProperty(basketData, 'upsertBasket: basket data');
 
     const {
@@ -45,6 +45,7 @@ export const getBasketServiceApi = (
       headers: {
         ...getRequestHeadersByChannel(channelId),
         ...getAuthHeader(jwt),
+        ...getPasswordHeader(checksum),
         ...additionalHeaders
       },
     })
@@ -75,7 +76,7 @@ export const getBasketServiceApi = (
     return data;
   };
 
-  const getBasket = async (reference: string, channelId?: string, returnTTId: boolean = false): Promise<BasketData> => {
+  const getBasket = async (reference: string, checksum: string, channelId?: string, returnTTId: boolean = false): Promise<BasketData> => {
     checkRequiredProperty(reference, 'getBasket: basket reference');
 
     const requestUrl = `${basketsPath}/${reference}?returnTTId=${returnTTId}`;
@@ -84,6 +85,7 @@ export const getBasketServiceApi = (
       {
         headers: {
           ...getRequestHeadersByChannel(channelId),
+          ...getPasswordHeader(checksum),
           ...additionalHeaders
         },
       }
@@ -92,7 +94,7 @@ export const getBasketServiceApi = (
     return data;
   };
 
-  const getDeliveries = async (reference: string, channelId?: string): Promise<DeliveryData[]> => {
+  const getDeliveries = async (reference: string, checksum: string, channelId?: string): Promise<DeliveryData[]> => {
     checkRequiredProperty(reference, 'getDeliveries: basket reference');
 
     const requestUrl = `${basketsPath}/${reference}${deliveriesPath}`;
@@ -101,6 +103,7 @@ export const getBasketServiceApi = (
       {
         headers: {
           ...getRequestHeadersByChannel(channelId),
+          ...getPasswordHeader(checksum),
           ...additionalHeaders
         },
       },
@@ -112,6 +115,7 @@ export const getBasketServiceApi = (
   const applyDelivery = async (
     reference: string,
     delivery: DeliveryData,
+    checksum: string,
     channelId?: string
   ): Promise<BasketData> => {
     checkRequiredProperty(reference, 'applyDelivery: basket reference');
@@ -124,6 +128,7 @@ export const getBasketServiceApi = (
       {
         headers: {
           ...getRequestHeadersByChannel(channelId),
+          ...getPasswordHeader(checksum),
           ...additionalHeaders
         },
       },

--- a/src/basket-service/services/repository-provider.ts
+++ b/src/basket-service/services/repository-provider.ts
@@ -16,32 +16,32 @@ export const getBasketServiceRepository = (
 
   basketDetailsRepositoryProvider.setEnvironment(environment, settings, sourceInformation);
 
-  const getBasket = async (reference: string, channelId?: string, returnTTId: boolean = false) => {
+  const getBasket = async (reference: string, checksum: string, channelId?: string, returnTTId: boolean = false) => {
     checkRequiredProperty(reference, 'getBasket: basket reference');
 
-    const basketData = await basketApi.getBasket(reference, channelId, returnTTId);
+    const basketData = await basketApi.getBasket(reference, checksum, channelId, returnTTId);
 
     return new Basket(basketData);
   };
 
-  const createBasket = async (basketData: RequestBasketData, returnTTId: boolean = false, jwt?: string) => {
+  const createBasket = async (basketData: RequestBasketData, checksum: string, returnTTId: boolean = false, jwt?: string) => {
     checkRequiredProperty(basketData, 'createBasket: basket data');
 
-    const responseBasketData = await basketApi.upsertBasket(basketData, returnTTId, jwt);
+    const responseBasketData = await basketApi.upsertBasket(basketData, checksum, returnTTId, jwt);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const getDeliveries = async (basketReference: string, basketItems: BasketItemsCollection, channelId?: string) => {
+  const getDeliveries = async (basketReference: string, basketItems: BasketItemsCollection, checksum: string, channelId?: string) => {
     checkRequiredProperty(basketReference, 'getDeliveries: basket reference');
     checkRequiredProperty(basketItems, 'getDeliveries: basket items collection');
 
-    const deliveries = await basketApi.getDeliveries(basketReference, channelId);
+    const deliveries = await basketApi.getDeliveries(basketReference, checksum, channelId);
 
     return deliveries.map(deliveryData => new Delivery(deliveryData, basketItems));
   };
 
-  const setSelectedDelivery = async (basket: Basket, selectedDelivery: DeliveryData) => {
+  const setSelectedDelivery = async (basket: Basket, selectedDelivery: DeliveryData, checksum: string) => {
     checkRequiredProperty(basket, 'setSelectedDelivery: basket');
     checkRequiredProperty(selectedDelivery, 'setSelectedDelivery: selected delivery data');
 
@@ -50,12 +50,12 @@ export const getBasketServiceRepository = (
     requestBasketData.delivery = selectedDelivery;
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData()};
 
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const addItems = async (basket: Basket, basketItems: BasketItemData[], returnTTId: boolean = false) => {
+  const addItems = async (basket: Basket, basketItems: BasketItemData[], checksum: string, returnTTId: boolean = false) => {
     checkRequiredProperty(basket, 'addItems: basket');
     checkRequiredProperty(basketItems, 'addItems: basket items collection');
 
@@ -64,12 +64,12 @@ export const getBasketServiceRepository = (
     requestBasketData.reservations = requestBasketData.reservations.concat(basketItems);
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData()};
 
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, returnTTId);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum, returnTTId);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const replaceItems = async (basket: Basket, basketItems: BasketItemData[], returnTTId: boolean = false) => {
+  const replaceItems = async (basket: Basket, basketItems: BasketItemData[], checksum: string, returnTTId: boolean = false) => {
     checkRequiredProperty(basket, 'replaceItems: basket');
     checkRequiredProperty(basketItems, 'replaceItems: basket items collection');
 
@@ -84,7 +84,7 @@ export const getBasketServiceRepository = (
 
     delete requestBasketData.reference;
 
-    return await createBasket(requestBasketData, returnTTId);
+    return await createBasket(requestBasketData, checksum, returnTTId);
   };
 
   const removeItem = async (basketReference: string, itemId: number, channelId?: string) => {
@@ -96,7 +96,7 @@ export const getBasketServiceRepository = (
     return new Basket(responseBasketData);
   };
 
-  const addPromoCode = async (basket: Basket, promoCode: string, returnTTId: boolean = false) => {
+  const addPromoCode = async (basket: Basket, promoCode: string, checksum: string, returnTTId: boolean = false) => {
     checkRequiredProperty(basket, 'addPromoCode: basket');
     checkRequiredProperty(promoCode, 'addPromoCode: promo code');
 
@@ -105,12 +105,12 @@ export const getBasketServiceRepository = (
     requestBasketData.coupon = { code: promoCode };
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData()};
 
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, returnTTId);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum, returnTTId);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const removePromoCode = async (basket: Basket, returnTTId: boolean = false) => {
+  const removePromoCode = async (basket: Basket, checksum: string, returnTTId: boolean = false) => {
     checkRequiredProperty(basket, 'removePromoCode: basket');
 
     let requestBasketData = basket.getBasketData();
@@ -118,28 +118,28 @@ export const getBasketServiceRepository = (
     requestBasketData.coupon = null;
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData()};
 
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, returnTTId);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum, returnTTId);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const setUpsellProducts = async (basket: Basket, upsellProducts: UpsellApiProductData, returnTTId: boolean = false) => {
+  const setUpsellProducts = async (basket: Basket, upsellProducts: UpsellApiProductData, checksum: string, returnTTId: boolean = false) => {
     checkRequiredProperty(basket, 'setUpsellProducts: basket');
     checkRequiredProperty(upsellProducts, 'setUpsellProducts: upsell products data');
 
     let requestBasketData = basket.getBasketData();
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData(upsellProducts)};
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, returnTTId);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum, returnTTId);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const upsertBasket = async (basket: Basket, basketData?: BasketData, returnTTId: boolean = false) => {
+  const upsertBasket = async (basket: Basket, checksum: string, basketData?: BasketData, returnTTId: boolean = false) => {
     const requestBasketData = basketData || basket.getBasketData();
     const responseBasketData = await basketApi.upsertBasket({
       ...requestBasketData,
       ...basket.prepareBasketData(),
-    }, returnTTId);
+    }, checksum, returnTTId);
 
     return new Basket(responseBasketData as BasketData);
   };

--- a/src/basket-service/services/repository-provider.ts
+++ b/src/basket-service/services/repository-provider.ts
@@ -16,32 +16,32 @@ export const getBasketServiceRepository = (
 
   basketDetailsRepositoryProvider.setEnvironment(environment, settings, sourceInformation);
 
-  const getBasket = async (reference: string, checksum: string, channelId?: string, returnTTId: boolean = false) => {
+  const getBasket = async (reference: string, channelId?: string, returnTTId: boolean = false, checksum?: string) => {
     checkRequiredProperty(reference, 'getBasket: basket reference');
 
-    const basketData = await basketApi.getBasket(reference, checksum, channelId, returnTTId);
+    const basketData = await basketApi.getBasket(reference, channelId, returnTTId, checksum);
 
     return new Basket(basketData);
   };
 
-  const createBasket = async (basketData: RequestBasketData, checksum: string, returnTTId: boolean = false, jwt?: string) => {
+  const createBasket = async (basketData: RequestBasketData, returnTTId: boolean = false, jwt?: string) => {
     checkRequiredProperty(basketData, 'createBasket: basket data');
 
-    const responseBasketData = await basketApi.upsertBasket(basketData, checksum, returnTTId, jwt);
+    const responseBasketData = await basketApi.upsertBasket(basketData, returnTTId, jwt);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const getDeliveries = async (basketReference: string, basketItems: BasketItemsCollection, checksum: string, channelId?: string) => {
+  const getDeliveries = async (basketReference: string, basketItems: BasketItemsCollection, channelId?: string, checksum?: string) => {
     checkRequiredProperty(basketReference, 'getDeliveries: basket reference');
     checkRequiredProperty(basketItems, 'getDeliveries: basket items collection');
 
-    const deliveries = await basketApi.getDeliveries(basketReference, checksum, channelId);
+    const deliveries = await basketApi.getDeliveries(basketReference, channelId, checksum);
 
     return deliveries.map(deliveryData => new Delivery(deliveryData, basketItems));
   };
 
-  const setSelectedDelivery = async (basket: Basket, selectedDelivery: DeliveryData, checksum: string) => {
+  const setSelectedDelivery = async (basket: Basket, selectedDelivery: DeliveryData, checksum?: string) => {
     checkRequiredProperty(basket, 'setSelectedDelivery: basket');
     checkRequiredProperty(selectedDelivery, 'setSelectedDelivery: selected delivery data');
 
@@ -50,12 +50,12 @@ export const getBasketServiceRepository = (
     requestBasketData.delivery = selectedDelivery;
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData()};
 
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, false, undefined, checksum);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const addItems = async (basket: Basket, basketItems: BasketItemData[], checksum: string, returnTTId: boolean = false) => {
+  const addItems = async (basket: Basket, basketItems: BasketItemData[], returnTTId: boolean = false, checksum?: string) => {
     checkRequiredProperty(basket, 'addItems: basket');
     checkRequiredProperty(basketItems, 'addItems: basket items collection');
 
@@ -64,12 +64,12 @@ export const getBasketServiceRepository = (
     requestBasketData.reservations = requestBasketData.reservations.concat(basketItems);
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData()};
 
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum, returnTTId);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, returnTTId, undefined, checksum);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const replaceItems = async (basket: Basket, basketItems: BasketItemData[], checksum: string, returnTTId: boolean = false) => {
+  const replaceItems = async (basket: Basket, basketItems: BasketItemData[], returnTTId: boolean = false) => {
     checkRequiredProperty(basket, 'replaceItems: basket');
     checkRequiredProperty(basketItems, 'replaceItems: basket items collection');
 
@@ -84,7 +84,7 @@ export const getBasketServiceRepository = (
 
     delete requestBasketData.reference;
 
-    return await createBasket(requestBasketData, checksum, returnTTId);
+    return await createBasket(requestBasketData, returnTTId);
   };
 
   const removeItem = async (basketReference: string, itemId: number, channelId?: string) => {
@@ -96,7 +96,7 @@ export const getBasketServiceRepository = (
     return new Basket(responseBasketData);
   };
 
-  const addPromoCode = async (basket: Basket, promoCode: string, checksum: string, returnTTId: boolean = false) => {
+  const addPromoCode = async (basket: Basket, promoCode: string, returnTTId: boolean = false, checksum?: string) => {
     checkRequiredProperty(basket, 'addPromoCode: basket');
     checkRequiredProperty(promoCode, 'addPromoCode: promo code');
 
@@ -105,12 +105,12 @@ export const getBasketServiceRepository = (
     requestBasketData.coupon = { code: promoCode };
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData()};
 
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum, returnTTId);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, returnTTId, undefined, checksum);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const removePromoCode = async (basket: Basket, checksum: string, returnTTId: boolean = false) => {
+  const removePromoCode = async (basket: Basket, returnTTId: boolean = false, checksum?: string) => {
     checkRequiredProperty(basket, 'removePromoCode: basket');
 
     let requestBasketData = basket.getBasketData();
@@ -118,28 +118,28 @@ export const getBasketServiceRepository = (
     requestBasketData.coupon = null;
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData()};
 
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum, returnTTId);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, returnTTId, undefined, checksum);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const setUpsellProducts = async (basket: Basket, upsellProducts: UpsellApiProductData, checksum: string, returnTTId: boolean = false) => {
+  const setUpsellProducts = async (basket: Basket, upsellProducts: UpsellApiProductData, returnTTId: boolean = false, checksum?: string) => {
     checkRequiredProperty(basket, 'setUpsellProducts: basket');
     checkRequiredProperty(upsellProducts, 'setUpsellProducts: upsell products data');
 
     let requestBasketData = basket.getBasketData();
     requestBasketData = { ...requestBasketData, ...basket.prepareBasketData(upsellProducts)};
-    const responseBasketData = await basketApi.upsertBasket(requestBasketData, checksum, returnTTId);
+    const responseBasketData = await basketApi.upsertBasket(requestBasketData, returnTTId, undefined, checksum);
 
     return new Basket(responseBasketData as BasketData);
   };
 
-  const upsertBasket = async (basket: Basket, checksum: string, basketData?: BasketData, returnTTId: boolean = false) => {
+  const upsertBasket = async (basket: Basket, basketData?: BasketData, returnTTId: boolean = false, checksum?: string) => {
     const requestBasketData = basketData || basket.getBasketData();
     const responseBasketData = await basketApi.upsertBasket({
       ...requestBasketData,
       ...basket.prepareBasketData(),
-    }, checksum, returnTTId);
+    }, returnTTId, undefined, checksum);
 
     return new Basket(responseBasketData as BasketData);
   };

--- a/src/utils/__tests__/additional-headers.spec.ts
+++ b/src/utils/__tests__/additional-headers.spec.ts
@@ -1,4 +1,4 @@
-import {getAdditionalHeaders, getAuthHeader, getCookieValue} from '../additional-headers';
+import {getAdditionalHeaders, getAuthHeader, getCookieValue, getPasswordHeader} from '../additional-headers';
 
 const sourceName = 'Source name';
 const sourceVersion = 'v1';
@@ -91,5 +91,19 @@ describe('getAuthHeader function', () => {
 
   it('if there is no jwt, return an empty object', () => {
     expect(getAuthHeader(undefined)).toEqual({});
+  });
+})
+
+describe('getPasswordHeader function', () => {
+  it('should return right header', () => {
+    const result = {
+      'x-ttg-password': 'checksum',
+    };
+
+    expect(getPasswordHeader('checksum')).toEqual(result);
+  });
+
+  it('if no checksum, return empty object', () => {
+    expect(getPasswordHeader(undefined)).toEqual({});
   });
 })

--- a/src/utils/additional-headers.ts
+++ b/src/utils/additional-headers.ts
@@ -65,3 +65,9 @@ export const getAuthHeader = (jwt?: string) => {
     'x-ttg-authorization': jwt,
   } : {};
 }
+
+export const getPasswordHeader = (checksum?: string) => {
+  return checksum ? {
+    'x-ttg-password': checksum,
+  } : {};
+}


### PR DESCRIPTION
## What are the relevant tasks?
https://app.shortcut.com/todaytix/story/100593/basket-service-gets-and-modifies-hold-details-directly-if-no-basket-exists

## What does this PR do & what background information is important for this PR?
This PR adds checksum as an optional param and header in basket service requests. This is because after moving off inventory service for BA seat selection, we may have holds with no baskets that still need to support checking out within the widgets. The idea is if a basket doesn't exist, basket service should try to get or update a hold instead, with the checksum as the secret. 

## Critical points
- I'm not including checksum for creating basket, clearing basket, or removing or replacing an item for now
- I chose the name `password` since that's what retailers are passing the checksum in as hitting checkout service `/channel` endpoint

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [ ] Ran locally: `npm run lint && npm run test-coverage`
- [ ] Bumped version on package.json