### PR TITLE
[sc-108345] Add support for setPromotionLabel on area pricing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tte-api-services",
-  "version": "1.31.4",
+  "version": "1.31.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/inventory-service/models/__tests__/area-pricing.spec.ts
+++ b/src/inventory-service/models/__tests__/area-pricing.spec.ts
@@ -159,7 +159,36 @@ describe('AreaPricing', () => {
 
       expect(promotionLabel).toBe('Test');
     })
-  })
+  });
+
+  describe('clearPromotionLabel function', () => {
+    it('should clear any existing promotionLabel if the new one is null', () => {
+      const newPromotionLabel = null;
+      const areaPricing = getAreaPricing();
+      areaPricing.setPromotionLabel(newPromotionLabel);
+      const promotionLabel = areaPricing.getPromotionLabel();
+
+      expect(promotionLabel).toBe(null);
+    });
+
+    it('should change the promotion label if the new one is a string', () => {
+      const newPromotionLabel = 'New Promo';
+      const areaPricing = getAreaPricing();
+      areaPricing.setPromotionLabel(newPromotionLabel);
+      const promotionLabel = areaPricing.getPromotionLabel();
+
+      expect(promotionLabel).toBe('New Promo');
+    });
+
+    it('should change the promotion label if the new one is a string', () => {
+      const newPromotionLabel = 'New Promo';
+      const areaPricing = getAreaPricing();
+      areaPricing.setPromotionLabel(newPromotionLabel);
+      const promotionLabel = areaPricing.getPromotionLabel();
+
+      expect(promotionLabel).toBe('New Promo');
+    });
+  });
 
   describe('getPriceReference function', () => {
     it('should get price reference', () => {

--- a/src/inventory-service/models/area-pricing.ts
+++ b/src/inventory-service/models/area-pricing.ts
@@ -69,6 +69,10 @@ export class AreaPricing {
     return this.promotionLabel;
   }
 
+  setPromotionLabel (promotionLabel: string | null) {
+    this.promotionLabel = promotionLabel;
+  }
+
   getPriceReference () {
     return this.priceReference;
   }


### PR DESCRIPTION
## What are the relevant tasks?
sc-108345

## What does this PR do & what background information is important for this PR?
Add a set method to override the promotion label or to clear it by setting it to null

## Checklist
- [x] Updated documentation (if required, see README.md)
- [x] Ran locally: `npm run lint && npm run test-coverage`
- [x] Bumped version on package.json