### PR TITLE
use existing domain for venueV3

### DIFF
--- a/src/venue-service/constants/path-settings.ts
+++ b/src/venue-service/constants/path-settings.ts
@@ -8,7 +8,7 @@ export const pathSettings = {
 };
 
 export const pathSettingsForV3 = {
-  [Environment.Prod]: 'https://venue.todaytixgroup.us',
+  [Environment.Prod]: 'https://venue-service.tixuk.io',
   [Environment.Qa]: 'https://venue-1.qa.ttix.io',
   [Environment.Staging]: 'https://venue.staging.ttix.io',
   [Environment.Dev]: 'https://venue.dev.ttix.io',


### PR DESCRIPTION
## What are the relevant tasks?

## What does this PR do & what background information is important for this PR?
Viator direct integrator has a whitelist of TTG domains to which the seat-plan widget can connect to, as the venue-service is using a new domain the widget is failing on their site.
[Changes were made](https://github.com/orgs/TodayTix/projects/13/views/3?pane=issue&itemId=53272901) to route the new service through the existing domain: `venue-service.tixuk.io`
Here we are hitting the new URL to allow the widget to work on Viator integration.

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [ ] Ran locally: `npm run lint && npm run test-coverage`
- [ ] Bumped version on package.json