### PR TITLE
fetching product data from platform

### DIFF
--- a/src/content-service/constants/path-settings.ts
+++ b/src/content-service/constants/path-settings.ts
@@ -5,20 +5,24 @@ export const pathSettings = {
     api: 'https://content-service.qatixuk.io/api/v1',
     apiV3: 'https://content-service.qatixuk.io/api/v3',
     images: 'https://content-service.devtixuk.com/images',
+    platform: 'https://dev.todaytix.com/api/v2',
   },
   [Environment.Qa]: {
     api: 'https://content-service.qatixuk.io/api/v1',
     apiV3: 'https://content-service.qatixuk.io/api/v3',
     images: 'https://content-service.qatixuk.com/images',
+    platform: 'https://qa.todaytix.com/api/v2',
   },
   [Environment.Staging]: {
     api: 'https://content-service.stagingtixuk.io/api/v1',
     apiV3: 'https://content-service.stagingtixuk.io/api/v3',
     images: 'https://content-service.stagingtixuk.com/images',
+    platform: 'https://staging.todaytix.com/api/v2',
   },
   [Environment.Prod]: {
     api: 'https://content-service.tixuk.io/api/v1',
     apiV3: 'https://content-service.tixuk.io/api/v3',
     images: 'https://content-service.tixuk.com/images',
+    platform: 'https://api.todaytix.com/api/v2',
   },
 };

--- a/src/content-service/services/__tests__/api-provider.spec.ts
+++ b/src/content-service/services/__tests__/api-provider.spec.ts
@@ -112,6 +112,20 @@ describe('Content service API', () => {
     });
   });
 
+  describe('getProductFromPlatform function', () => {
+    it('should get product from platform', async () => {
+      const id = '123';
+      await contentServiceApi.getProductFromPlatform(id);
+
+      expect(mockGet).toBeCalledWith(
+        `/shows/${id}`,
+        {
+          headers: additionalHeaders,
+        },
+      );
+    });
+  });
+
   describe('getImages function', () => {
     it('should get images with specific size', () => {
       const productEntity = EntityType.Products;

--- a/src/content-service/services/api-provider.ts
+++ b/src/content-service/services/api-provider.ts
@@ -2,7 +2,7 @@ import { getHttpClient } from '../../http-client-provider';
 import { checkRequiredProperty, getAdditionalHeaders } from '../../utils';
 import { pathSettings } from '../constants/path-settings';
 import { imageSizes } from '../constants/image-sizes';
-import { ApiProductData, EntityType, ImageOrientation, Image, ApiProductDataV3 } from '../typings';
+import { ApiProductData, EntityType, ImageOrientation, Image, ApiProductDataV3, ApiProductPlatformData } from '../typings';
 import { Environment, Settings, SourceInformation } from '../../shared/typings';
 
 export const getContentServiceApi = (
@@ -15,13 +15,17 @@ export const getContentServiceApi = (
   const baseContentApiUrl = settings?.contentApiUrl || pathSettings[environment].api;
   const baseContentApiUrlForV3 = settings?.contentApiUrlV3 || pathSettings[environment].apiV3;
   const baseContentImagesUrl = settings?.contentImagesUrl || pathSettings[environment].images;
+  const basePlatformApiUrl = settings?.basePlatformApiUrl || pathSettings[environment].platform;
 
   const httpClient = getHttpClient(baseContentApiUrl);
   const httpClientForV3 = getHttpClient(baseContentApiUrlForV3);
+  const httpClientForPlatform = getHttpClient(basePlatformApiUrl);
 
   const productsPath = '/products';
+  const platformProductBasePath = '/shows';
   const additionalHeaders = getAdditionalHeaders(sourceInformation);
   const additionalHeadersForV3 = getAdditionalHeaders(sourceInformation, false, true);
+  const additionalHeadersForPlatform = getAdditionalHeaders(sourceInformation, false, true);
 
   const getProducts = async (page?: number, limit?: number): Promise<ApiProductData[]> => {
     let requestUrl = productsPath;
@@ -74,6 +78,19 @@ export const getContentServiceApi = (
     return { id: data.id, venueChartKey: data.venueChartKey };
   };
 
+  const getProductFromPlatform = async (id: string): Promise<ApiProductPlatformData> => {
+    const requestUrl = `${platformProductBasePath}/${id}`;
+
+    const { data } = await httpClientForPlatform.get(
+      requestUrl,
+      {
+        headers: additionalHeadersForPlatform,
+      },
+    );
+
+    return { id: data.id, venueChartKey: data.venueChartKey };
+  };
+
   const getImages = (
     entityType: EntityType,
     entityId: string,
@@ -97,6 +114,7 @@ export const getContentServiceApi = (
     getProducts,
     getProduct,
     getProductFromV3,
+    getProductFromPlatform,
     getImages,
   };
 };

--- a/src/content-service/typings/index.ts
+++ b/src/content-service/typings/index.ts
@@ -24,6 +24,11 @@ export interface ApiProductDataV3 {
   venueChartKey: string;
 }
 
+export interface ApiProductPlatformData {
+  id: string;
+  venueChartKey: string;
+}
+
 export interface ApiRegionData {
   name: string;
   isoCode: string;

--- a/src/shared/typings/index.ts
+++ b/src/shared/typings/index.ts
@@ -35,6 +35,7 @@ export interface Settings {
   contentApiUrl?: string;
   contentApiUrlV3?: string;
   contentImagesUrl?: string;
+  basePlatformApiUrl?: string;
 }
 
 export interface ApiPricingValue {


### PR DESCRIPTION
## What are the relevant tasks?
Getting out of seats.io
## What does this PR do & what background information is important for this PR?
This adds methods to fetch product data directly from platform API instead of content service.
Changes are being made in [platform](https://github.com/TodayTix/platform/pull/12680) to expose the `venueChartKey` so we can grab the chart key directly from there.

## Checklist
- [ ] Updated documentation (if required, see README.md)
- [ ] Ran locally: `npm run lint && npm run test-coverage`
- [ ] Bumped version on package.json